### PR TITLE
Aktualisierung der github workflow actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Advance Security Compliance Action
-        uses: GeekMasher/advanced-security-compliance@v1.6
+        uses: GeekMasher/advanced-security-compliance@v1.7.0
         with:
           policy: GeekMasher/security-queries
           policy-path: policies/default.yml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Advance Security Compliance Action
         uses: GeekMasher/advanced-security-compliance@v1.6


### PR DESCRIPTION
**Description**
Da eure Github-Actions nicht mehr gelaufen sind, habe ich mir den Fehler näher angeschaut und mit zwei Commits beheben können. 

Einmal war die ```actions/checkout``` von Node JS 12 auf 16 im Hintergrund aktualisiert worden. Warum man diese von v2 auf v3 aktualisieren musste.

Weiter war die ```GeekMasher/advanced-security-compliance``` auch veraltet und hat noch einen Fehler gebracht, was mit der Inkompatibilität von Node JS wohl nun zusammen gehangen hat.

Beides ist behoben und die Github-Actions arbeiten wieder richtig.

Bei Rückfragen bitte einfach mir schreiben.
