### PR TITLE
Add default maxlength to all string values in dtos

### DIFF
--- a/src/main/java/de/muenchen/isi/api/dto/AbfrageDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/AbfrageDto.java
@@ -15,6 +15,7 @@ import lombok.Data;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -25,6 +26,7 @@ public class AbfrageDto {
     @HasAllowedNumberOfDocuments
     private List<@Valid DokumentDto> dokumente;
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String allgemeineOrtsangabe;
 
     @Valid
@@ -33,11 +35,13 @@ public class AbfrageDto {
     @NotNull
     private LocalDate fristStellungnahme;
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String anmerkung;
 
     @NotNull
     private StatusAbfrage statusAbfrage;
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String bebauungsplannummer;
 
     @NotBlank

--- a/src/main/java/de/muenchen/isi/api/dto/BauabschnittDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/BauabschnittDto.java
@@ -8,6 +8,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @Data
@@ -16,6 +17,7 @@ import java.util.List;
 public class BauabschnittDto extends BaseEntityDto {
 
     @NotBlank
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String bezeichnung;
 
     @NotEmpty

--- a/src/main/java/de/muenchen/isi/api/dto/BaugebietDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/BaugebietDto.java
@@ -9,6 +9,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @Data
@@ -17,6 +18,7 @@ import java.util.List;
 public class BaugebietDto extends BaseEntityDto {
 
     @NotBlank
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String bezeichnung;
 
     @NotNull

--- a/src/main/java/de/muenchen/isi/api/dto/BauvorhabenDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/BauvorhabenDto.java
@@ -14,15 +14,18 @@ import lombok.Data;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @Data
 public class BauvorhabenDto extends BaseEntityDto {
 
     @NotEmpty
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String nameVorhaben;
 
     @NotEmpty
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String eigentuemer;
 
     @NotNull
@@ -33,17 +36,22 @@ public class BauvorhabenDto extends BaseEntityDto {
     private StandVorhaben standVorhaben;
 
     @NotEmpty
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String bauvorhabenNummer;
 
     @Valid
     private AdresseDto adresse;
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String allgemeineOrtsangabe;
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String bebauungsplannummer;
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String fisNummer;
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String anmerkung;
 
     @NotNull

--- a/src/main/java/de/muenchen/isi/api/dto/InfrastrukturabfrageDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/InfrastrukturabfrageDto.java
@@ -36,11 +36,13 @@ public class InfrastrukturabfrageDto extends BaseEntityDto {
     @Size(min = 1, max = 5)
     private List<@Valid @NotNull AbfragevarianteDto> abfragevarianten;
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String aktenzeichenProLbk;
 
     @NotNull
     @NotUnspecified
     private UncertainBoolean offiziellerVerfahrensschritt;
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String displayName;
 }

--- a/src/main/java/de/muenchen/isi/api/dto/common/AdresseDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/common/AdresseDto.java
@@ -8,13 +8,23 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Size;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class AdresseDto {
+
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String plz;
+
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String ort;
+
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String strasse;
+
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String hausnummer;
 
 }

--- a/src/main/java/de/muenchen/isi/api/dto/common/InfrastrukturDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/common/InfrastrukturDto.java
@@ -2,11 +2,15 @@ package de.muenchen.isi.api.dto.common;
 
 import lombok.Data;
 
+import javax.validation.constraints.Size;
+
 @Data
 public class InfrastrukturDto {
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String infrastrukturplanung;
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String beschlussvorlage;
 
 }

--- a/src/main/java/de/muenchen/isi/api/dto/common/StadtbezirkDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/common/StadtbezirkDto.java
@@ -2,10 +2,14 @@ package de.muenchen.isi.api.dto.common;
 
 import lombok.Data;
 
+import javax.validation.constraints.Size;
+
 @Data
 public class StadtbezirkDto {
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String nummer;
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String name;
 }

--- a/src/main/java/de/muenchen/isi/api/dto/common/UtmDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/common/UtmDto.java
@@ -5,11 +5,14 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 @Data
 @NoArgsConstructor
 @Embeddable
 public class UtmDto {
+
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String zone;
 
     @NotNull

--- a/src/main/java/de/muenchen/isi/api/dto/infrastruktureinrichtung/InfrastruktureinrichtungDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/infrastruktureinrichtung/InfrastruktureinrichtungDto.java
@@ -11,6 +11,8 @@ import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusInfrastrukturein
 import lombok.Data;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -35,6 +37,8 @@ public class InfrastruktureinrichtungDto {
     private String nameEinrichtung;
 
     @NotNull
+    @Min(1900)
+    @Max(2100)
     private Integer fertigstellungsjahr; // JJJJ
 
     @NotNull

--- a/src/main/java/de/muenchen/isi/api/dto/infrastruktureinrichtung/InfrastruktureinrichtungDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/infrastruktureinrichtung/InfrastruktureinrichtungDto.java
@@ -13,6 +13,7 @@ import lombok.Data;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.UUID;
 
@@ -23,12 +24,14 @@ public class InfrastruktureinrichtungDto {
 
     private UUID bauvorhaben;
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String allgemeineOrtsangabe;
 
     @Valid
     private AdresseDto adresse;
 
     @NotBlank
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String nameEinrichtung;
 
     @NotNull

--- a/src/main/java/de/muenchen/isi/api/dto/list/AbfrageListElementDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/list/AbfrageListElementDto.java
@@ -5,6 +5,7 @@ import de.muenchen.isi.infrastructure.entity.enums.lookup.StandVorhaben;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusAbfrage;
 import lombok.Data;
 
+import javax.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -13,6 +14,7 @@ public class AbfrageListElementDto {
 
     private UUID id;
 
+    @Size(max = 70, message = "Es sind maximal {max} Zeichen erlaubt")
     private String nameAbfrage;
 
     private StandVorhaben standVorhaben;

--- a/src/main/java/de/muenchen/isi/api/dto/list/InfrastruktureinrichtungListElementDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/list/InfrastruktureinrichtungListElementDto.java
@@ -3,6 +3,7 @@ package de.muenchen.isi.api.dto.list;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.InfrastruktureinrichtungTyp;
 import lombok.Data;
 
+import javax.validation.constraints.Size;
 import java.util.UUID;
 
 @Data
@@ -10,6 +11,7 @@ public class InfrastruktureinrichtungListElementDto {
 
     private UUID id;
 
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String nameEinrichtung;
 
     private InfrastruktureinrichtungTyp infrastruktureinrichtungTyp;

--- a/src/main/java/de/muenchen/isi/api/dto/stammdaten/FoerdermixStammDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/stammdaten/FoerdermixStammDto.java
@@ -22,10 +22,11 @@ import javax.validation.constraints.Size;
 public class FoerdermixStammDto extends BaseEntityDto {
 
     @NotEmpty
+    @Size(max = 255, message = "Es sind maximal {max} Zeichen erlaubt")
     private String bezeichnungJahr;
 
     @NotEmpty
-    @Size(max = 80)
+    @Size(max = 80, message = "Es sind maximal {max} Zeichen erlaubt")
     private String bezeichnung;
 
     @NotNull


### PR DESCRIPTION
**Description**

Zu jedem String wurde die default `@Size(max = 255) `hinzugefügt. 

**Reference**

Issues ISI-309
