### PR TITLE
ISI-563 Bugfix mutliple identische Abfragevariante bei Referenzierung Bauvorhaben mit mehreren gewählten Flurstücken

### DIFF
--- a/src/main/java/de/muenchen/isi/api/dto/common/FlurstueckDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/common/FlurstueckDto.java
@@ -1,17 +1,12 @@
 package de.muenchen.isi.api.dto.common;
 
-import de.muenchen.isi.api.dto.BaseEntityDto;
 import java.math.BigDecimal;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 @Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-public class FlurstueckDto extends BaseEntityDto {
+public class FlurstueckDto {
 
     private String nummer;
 

--- a/src/main/java/de/muenchen/isi/api/dto/common/GemarkungDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/common/GemarkungDto.java
@@ -1,18 +1,13 @@
 package de.muenchen.isi.api.dto.common;
 
-import de.muenchen.isi.api.dto.BaseEntityDto;
 import java.math.BigDecimal;
 import java.util.Set;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 @Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-public class GemarkungDto extends BaseEntityDto {
+public class GemarkungDto {
 
     private BigDecimal nummer;
 

--- a/src/main/java/de/muenchen/isi/api/dto/common/StadtbezirkDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/common/StadtbezirkDto.java
@@ -1,16 +1,11 @@
 package de.muenchen.isi.api.dto.common;
 
-import de.muenchen.isi.api.dto.BaseEntityDto;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 @Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-public class StadtbezirkDto extends BaseEntityDto {
+public class StadtbezirkDto {
 
     private String nummer;
 

--- a/src/main/java/de/muenchen/isi/api/dto/common/VerortungDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/common/VerortungDto.java
@@ -1,18 +1,13 @@
 package de.muenchen.isi.api.dto.common;
 
-import de.muenchen.isi.api.dto.BaseEntityDto;
 import java.util.Set;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 @Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-public class VerortungDto extends BaseEntityDto {
+public class VerortungDto {
 
     @NotEmpty
     private Set<@Valid StadtbezirkDto> stadtbezirke;

--- a/src/main/java/de/muenchen/isi/domain/model/common/FlurstueckModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/common/FlurstueckModel.java
@@ -1,15 +1,10 @@
 package de.muenchen.isi.domain.model.common;
 
-import de.muenchen.isi.domain.model.BaseEntityModel;
 import java.math.BigDecimal;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 @Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-public class FlurstueckModel extends BaseEntityModel {
+public class FlurstueckModel {
 
     private String nummer;
 

--- a/src/main/java/de/muenchen/isi/domain/model/common/GemarkungModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/common/GemarkungModel.java
@@ -1,16 +1,11 @@
 package de.muenchen.isi.domain.model.common;
 
-import de.muenchen.isi.domain.model.BaseEntityModel;
 import java.math.BigDecimal;
 import java.util.Set;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 @Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-public class GemarkungModel extends BaseEntityModel {
+public class GemarkungModel {
 
     private BigDecimal nummer;
 

--- a/src/main/java/de/muenchen/isi/domain/model/common/StadtbezirkModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/common/StadtbezirkModel.java
@@ -1,14 +1,9 @@
 package de.muenchen.isi.domain.model.common;
 
-import de.muenchen.isi.domain.model.BaseEntityModel;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 @Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-public class StadtbezirkModel extends BaseEntityModel {
+public class StadtbezirkModel {
 
     private String nummer;
 

--- a/src/main/java/de/muenchen/isi/domain/model/common/VerortungModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/common/VerortungModel.java
@@ -1,15 +1,10 @@
 package de.muenchen.isi.domain.model.common;
 
-import de.muenchen.isi.domain.model.BaseEntityModel;
 import java.util.Set;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 @Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-public class VerortungModel extends BaseEntityModel {
+public class VerortungModel {
 
     private Set<StadtbezirkModel> stadtbezirke;
 

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/Abfrage.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/Abfrage.java
@@ -9,6 +9,7 @@ import de.muenchen.isi.infrastructure.entity.common.Verortung;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StandVorhaben;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusAbfrage;
 import de.muenchen.isi.infrastructure.entity.filehandling.Dokument;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
 import java.time.LocalDate;
 import java.util.List;
 import javax.persistence.CascadeType;
@@ -21,11 +22,13 @@ import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
 import lombok.Data;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 
 @Embeddable
 @Data
+@TypeDef(name = "json", typeClass = JsonType.class)
 public class Abfrage {
 
     @OneToMany(cascade = { CascadeType.ALL }, fetch = FetchType.LAZY, orphanRemoval = true)
@@ -38,7 +41,8 @@ public class Abfrage {
     @Embedded
     private Adresse adresse;
 
-    @OneToOne(cascade = { CascadeType.ALL }, fetch = FetchType.EAGER, orphanRemoval = true)
+    @Type(type = "json")
+    @Column(nullable = false, columnDefinition = "json")
     private Verortung verortung;
 
     @Column(nullable = false)

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/Abfrage.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/Abfrage.java
@@ -42,7 +42,7 @@ public class Abfrage {
     private Adresse adresse;
 
     @Type(type = "json")
-    @Column(nullable = false, columnDefinition = "json")
+    @Column(columnDefinition = "json")
     private Verortung verortung;
 
     @Column(nullable = false)

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/Abfrage.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/Abfrage.java
@@ -42,7 +42,7 @@ public class Abfrage {
     private Adresse adresse;
 
     @Type(type = "json")
-    @Column(columnDefinition = "json")
+    @Column(columnDefinition = "jsonb")
     private Verortung verortung;
 
     @Column(nullable = false)

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/Bauvorhaben.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/Bauvorhaben.java
@@ -55,7 +55,7 @@ public class Bauvorhaben extends BaseEntity {
     private Adresse adresse;
 
     @Type(type = "json")
-    @Column(columnDefinition = "json")
+    @Column(columnDefinition = "jsonb")
     private Verortung verortung;
 
     @Column(nullable = true)

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/Bauvorhaben.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/Bauvorhaben.java
@@ -7,6 +7,7 @@ import de.muenchen.isi.infrastructure.entity.enums.lookup.Planungsrecht;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StandVorhaben;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.UncertainBoolean;
 import de.muenchen.isi.infrastructure.entity.filehandling.Dokument;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -19,17 +20,19 @@ import javax.persistence.FetchType;
 import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 
 @Entity
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @Table(indexes = { @Index(name = "name_vorhaben_index", columnList = "nameVorhaben") })
+@TypeDef(name = "json", typeClass = JsonType.class)
 public class Bauvorhaben extends BaseEntity {
 
     @Column(nullable = false, unique = true)
@@ -51,7 +54,8 @@ public class Bauvorhaben extends BaseEntity {
     @Embedded
     private Adresse adresse;
 
-    @OneToOne(cascade = { CascadeType.ALL }, fetch = FetchType.EAGER, orphanRemoval = true)
+    @Type(type = "json")
+    @Column(nullable = false, columnDefinition = "json")
     private Verortung verortung;
 
     @Column(nullable = true)

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/Bauvorhaben.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/Bauvorhaben.java
@@ -55,7 +55,7 @@ public class Bauvorhaben extends BaseEntity {
     private Adresse adresse;
 
     @Type(type = "json")
-    @Column(nullable = false, columnDefinition = "json")
+    @Column(columnDefinition = "json")
     private Verortung verortung;
 
     @Column(nullable = true)

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/common/Flurstueck.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/common/Flurstueck.java
@@ -1,44 +1,24 @@
 package de.muenchen.isi.infrastructure.entity.common;
 
-import de.muenchen.isi.infrastructure.entity.BaseEntity;
 import java.math.BigDecimal;
-import javax.persistence.Column;
-import javax.persistence.Embedded;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-@Entity
 @Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-@EntityListeners(AuditingEntityListener.class)
-public class Flurstueck extends BaseEntity {
+public class Flurstueck {
 
-    @Column(nullable = true)
     private String nummer;
 
-    @Column(nullable = true)
     private BigDecimal flaecheQm;
 
-    @Column(nullable = true)
     private Long zaehler;
 
-    @Column(nullable = true)
     private Long nenner;
 
-    @Column(nullable = true)
     private Long eigentumsart;
 
-    @Column(nullable = true)
     private String eigentumsartBedeutung;
 
-    @Column(nullable = false)
     private BigDecimal gemarkungNummer;
 
-    @Embedded
     private MultiPolygonGeometry multiPolygon;
 }

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/common/Gemarkung.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/common/Gemarkung.java
@@ -1,38 +1,17 @@
 package de.muenchen.isi.infrastructure.entity.common;
 
-import de.muenchen.isi.infrastructure.entity.BaseEntity;
 import java.math.BigDecimal;
 import java.util.Set;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Embedded;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToMany;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-@Entity
 @Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-@EntityListeners(AuditingEntityListener.class)
-public class Gemarkung extends BaseEntity {
+public class Gemarkung {
 
-    @Column(nullable = false)
     private BigDecimal nummer;
 
-    @Column(nullable = false)
     private String name;
 
-    @OneToMany(cascade = { CascadeType.ALL }, fetch = FetchType.EAGER, orphanRemoval = true)
-    @JoinColumn(name = "gemarkung_id", referencedColumnName = "id")
     private Set<Flurstueck> flurstuecke;
 
-    @Embedded
     private MultiPolygonGeometry multiPolygon;
 }

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/common/Geometry.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/common/Geometry.java
@@ -1,13 +1,9 @@
 package de.muenchen.isi.infrastructure.entity.common;
 
-import javax.persistence.Column;
-import javax.persistence.MappedSuperclass;
 import lombok.Data;
 
-@MappedSuperclass
 @Data
 public abstract class Geometry {
 
-    @Column(nullable = false)
     private String type;
 }

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/common/MultiPolygonGeometry.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/common/MultiPolygonGeometry.java
@@ -1,24 +1,15 @@
 package de.muenchen.isi.infrastructure.entity.common;
 
-import io.hypersistence.utils.hibernate.type.json.JsonType;
 import java.math.BigDecimal;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
 
-@Embeddable
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-@TypeDef(name = "json", typeClass = JsonType.class)
 public class MultiPolygonGeometry extends Geometry {
 
-    @Type(type = "json")
-    @Column(nullable = false, columnDefinition = "json")
     private List<List<List<List<BigDecimal>>>> coordinates;
 }

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/common/Stadtbezirk.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/common/Stadtbezirk.java
@@ -1,28 +1,13 @@
 package de.muenchen.isi.infrastructure.entity.common;
 
-import de.muenchen.isi.infrastructure.entity.BaseEntity;
-import javax.persistence.Column;
-import javax.persistence.Embedded;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-@Entity
 @Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-@EntityListeners(AuditingEntityListener.class)
-public class Stadtbezirk extends BaseEntity {
+public class Stadtbezirk {
 
-    @Column(nullable = false)
     private String nummer;
 
-    @Column(nullable = false)
     private String name;
 
-    @Embedded
     private MultiPolygonGeometry multiPolygon;
 }

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/common/Verortung.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/common/Verortung.java
@@ -1,34 +1,14 @@
 package de.muenchen.isi.infrastructure.entity.common;
 
-import de.muenchen.isi.infrastructure.entity.BaseEntity;
 import java.util.Set;
-import javax.persistence.CascadeType;
-import javax.persistence.Embedded;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToMany;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-@Entity
 @Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-@EntityListeners(AuditingEntityListener.class)
-public class Verortung extends BaseEntity {
+public class Verortung {
 
-    @OneToMany(cascade = { CascadeType.ALL }, fetch = FetchType.EAGER, orphanRemoval = true)
-    @JoinColumn(name = "verortung_id", referencedColumnName = "id")
     private Set<Stadtbezirk> stadtbezirke;
 
-    @OneToMany(cascade = { CascadeType.ALL }, fetch = FetchType.EAGER, orphanRemoval = true)
-    @JoinColumn(name = "verortung_id", referencedColumnName = "id")
     private Set<Gemarkung> gemarkungen;
 
-    @Embedded
     private MultiPolygonGeometry multiPolygon;
 }


### PR DESCRIPTION
**Description**

* Umstellung der Entität `Verortung` auf JSON. 
* Die Entitäten Bauvorhaben und Infrastrukturabfrage speichern das Verortungsobjekt in eine Tabellenattribut in JSON.
* Verwendung von `jsonb` (Binary JSON) als Datentyp.
https://vladmihalcea.com/how-to-map-json-objects-using-generic-hibernate-types/
![image](https://github.com/it-at-m/isi-backend/assets/56300801/8cbb0fc3-fcd4-4c33-8ecd-309ce0d2fe4f)

**Reference**

ISI-563
