### PR TITLE
ISI-827-Löschen-von-Abfragen-durch-Abfrageersteller

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "lint": "npx prettier --write --ignore-unknown ."
   },
   "devDependencies": {
-    "husky": "^8.0.2",
-    "lint-staged": "^13.2.0",
-    "prettier": "2.8.4",
-    "prettier-plugin-java": "^2.1.0"
+    "husky": "8.0.3",
+    "lint-staged": "14.0.1",
+    "prettier": "3.0.3",
+    "prettier-plugin-java": "2.3.1"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"

--- a/src/main/java/de/muenchen/isi/domain/mapper/AbfrageDomainMapper.java
+++ b/src/main/java/de/muenchen/isi/domain/mapper/AbfrageDomainMapper.java
@@ -54,6 +54,7 @@ public abstract class AbfrageDomainMapper {
         {
             @Mapping(target = "abfrage.statusAbfrage", ignore = true),
             @Mapping(target = "id", ignore = true),
+            @Mapping(target = "sub", ignore = true),
             @Mapping(target = "createdDateTime", ignore = true),
             @Mapping(target = "lastModifiedDateTime", ignore = true),
             @Mapping(target = "abfragevarianten", ignore = true),

--- a/src/main/java/de/muenchen/isi/domain/model/InfrastrukturabfrageModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/InfrastrukturabfrageModel.java
@@ -19,6 +19,8 @@ public class InfrastrukturabfrageModel extends BaseEntityModel {
 
     private AbfrageModel abfrage;
 
+    private String sub;
+
     private UncertainBoolean sobonRelevant;
 
     private SobonVerfahrensgrundsaetzeJahr sobonJahr;

--- a/src/main/java/de/muenchen/isi/domain/service/AbfrageService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/AbfrageService.java
@@ -241,7 +241,7 @@ public class AbfrageService {
     public void deleteInfrasturkturabfrageById(final UUID id)
             throws EntityNotFoundException, EntityIsReferencedException, UserRoleNotAllowedException, AbfrageStatusNotAllowedException {
         final var abfrage = this.getInfrastrukturabfrageById(id);
-        if (abfrage.getSub() == authenticationUtils.getUserSub()) {
+        if (abfrage.getSub().equals(authenticationUtils.getUserSub())) {
             this.throwUserRoleNotAllowedOrAbfrageStatusNotAlloweExceptionWhenDeleteAbfrage(abfrage.getAbfrage());
             this.throwEntityIsReferencedExceptionWhenAbfrageIsReferencingBauvorhaben(abfrage.getAbfrage());
             this.infrastrukturabfrageRepository.deleteById(id);

--- a/src/main/java/de/muenchen/isi/domain/service/AbfrageService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/AbfrageService.java
@@ -246,8 +246,7 @@ public class AbfrageService {
             this.throwEntityIsReferencedExceptionWhenAbfrageIsReferencingBauvorhaben(abfrage.getAbfrage());
             this.infrastrukturabfrageRepository.deleteById(id);
         } else {
-            log.error(abfrage.getSub());
-            log.error(authenticationUtils.getUserSub());
+            log.error("User {} hat versucht, die Abfrage {} von User {} zu löschen.", authenticationUtils.getUserSub(), id, abfrage.getSub());
             throw new UserRoleNotAllowedException("Keine Berechtigung zum Löschen der Abfrage");
         }
     }

--- a/src/main/java/de/muenchen/isi/domain/service/AbfrageService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/AbfrageService.java
@@ -20,11 +20,6 @@ import de.muenchen.isi.domain.service.filehandling.DokumentService;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusAbfrage;
 import de.muenchen.isi.infrastructure.repository.InfrastrukturabfrageRepository;
 import de.muenchen.isi.security.AuthenticationUtils;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -33,6 +28,12 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -54,8 +55,8 @@ public class AbfrageService {
      */
     public List<InfrastrukturabfrageModel> getInfrastrukturabfragen() {
         return this.infrastrukturabfrageRepository.findAllByOrderByAbfrageFristStellungnahmeDesc()
-            .map(this.abfrageDomainMapper::entity2Model)
-            .collect(Collectors.toList());
+                .map(this.abfrageDomainMapper::entity2Model)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -84,15 +85,15 @@ public class AbfrageService {
      * @throws OptimisticLockingException falls in der Anwendung bereits eine neuere Version der Entität gespeichert ist
      */
     public InfrastrukturabfrageModel saveInfrastrukturabfrage(final InfrastrukturabfrageModel abfrage)
-        throws UniqueViolationException, OptimisticLockingException {
+            throws UniqueViolationException, OptimisticLockingException {
         if (abfrage.getId() == null) {
             abfrage.getAbfrage().setStatusAbfrage(StatusAbfrage.ANGELEGT);
             abfrage.setSub(authenticationUtils.getUserSub());
         }
         var abfrageEntity = this.abfrageDomainMapper.model2entity(abfrage);
         final var saved =
-            this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase(
-                    abfrageEntity.getAbfrage().getNameAbfrage()
+                this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase(
+                        abfrageEntity.getAbfrage().getNameAbfrage()
                 );
         if ((saved.isPresent() && saved.get().getId().equals(abfrageEntity.getId())) || saved.isEmpty()) {
             try {
@@ -102,13 +103,13 @@ public class AbfrageService {
                 throw new OptimisticLockingException(message, exception);
             } catch (final DataIntegrityViolationException exception) {
                 final var message =
-                    "Der angegebene Name der Abfragevariante ist schon vorhanden, bitte wählen Sie daher einen anderen Namen und speichern Sie die Abfrage erneut.";
+                        "Der angegebene Name der Abfragevariante ist schon vorhanden, bitte wählen Sie daher einen anderen Namen und speichern Sie die Abfrage erneut.";
                 throw new UniqueViolationException(message);
             }
             return this.abfrageDomainMapper.entity2Model(abfrageEntity);
         } else {
             throw new UniqueViolationException(
-                "Der angegebene Name der Abfrage ist schon vorhanden, bitte wählen Sie daher einen anderen Namen und speichern Sie die Abfrage erneut."
+                    "Der angegebene Name der Abfrage ist schon vorhanden, bitte wählen Sie daher einen anderen Namen und speichern Sie die Abfrage erneut."
             );
         }
     }
@@ -128,18 +129,18 @@ public class AbfrageService {
      */
     @Transactional
     public InfrastrukturabfrageModel patchAbfrageAngelegt(
-        final InfrastrukturabfrageAngelegtModel abfrage,
-        final UUID id
+            final InfrastrukturabfrageAngelegtModel abfrage,
+            final UUID id
     )
-        throws EntityNotFoundException, UniqueViolationException, OptimisticLockingException, AbfrageStatusNotAllowedException, FileHandlingFailedException, FileHandlingWithS3FailedException {
+            throws EntityNotFoundException, UniqueViolationException, OptimisticLockingException, AbfrageStatusNotAllowedException, FileHandlingFailedException, FileHandlingWithS3FailedException {
         final var originalAbfrageDb = this.getInfrastrukturabfrageById(id);
         this.throwAbfrageStatusNotAllowedExceptionWhenStatusAbfrageIsInvalid(
                 originalAbfrageDb.getAbfrage(),
                 StatusAbfrage.ANGELEGT
-            );
+        );
         dokumentService.deleteDokumenteFromOriginalDokumentenListWhichAreMissingInParameterAdaptedDokumentenListe(
-            abfrage.getAbfrage().getDokumente(),
-            originalAbfrageDb.getAbfrage().getDokumente()
+                abfrage.getAbfrage().getDokumente(),
+                originalAbfrageDb.getAbfrage().getDokumente()
         );
         final var abfrageToSave = this.abfrageDomainMapper.request2Model(abfrage, originalAbfrageDb);
         return this.saveInfrastrukturabfrage(abfrageToSave);
@@ -156,15 +157,15 @@ public class AbfrageService {
      * @throws OptimisticLockingException falls in der Anwendung bereits eine neuere Version der Entität gespeichert ist
      */
     public InfrastrukturabfrageModel patchAbfrageInBearbeitungSachbearbeitung(
-        final InfrastrukturabfrageInBearbeitungSachbearbeitungModel abfrage,
-        final UUID id
+            final InfrastrukturabfrageInBearbeitungSachbearbeitungModel abfrage,
+            final UUID id
     )
-        throws EntityNotFoundException, AbfrageStatusNotAllowedException, UniqueViolationException, OptimisticLockingException {
+            throws EntityNotFoundException, AbfrageStatusNotAllowedException, UniqueViolationException, OptimisticLockingException {
         final var originalAbfrageDb = this.getInfrastrukturabfrageById(id);
         this.throwAbfrageStatusNotAllowedExceptionWhenStatusAbfrageIsInvalid(
                 originalAbfrageDb.getAbfrage(),
                 StatusAbfrage.IN_BEARBEITUNG_SACHBEARBEITUNG
-            );
+        );
         final var abfrageToSave = this.abfrageDomainMapper.request2Model(abfrage, originalAbfrageDb);
         return this.saveInfrastrukturabfrage(abfrageToSave);
     }
@@ -184,24 +185,24 @@ public class AbfrageService {
      * @throws BauvorhabenNotReferencedException falls die Abfrage zu keinem Bauvorhaben dazugehört
      */
     public InfrastrukturabfrageModel changeAbfragevarianteRelevant(final UUID abfrageId, final UUID abfragevarianteId)
-        throws EntityNotFoundException, UniqueViolationException, OptimisticLockingException, AbfrageStatusNotAllowedException, BauvorhabenNotReferencedException {
+            throws EntityNotFoundException, UniqueViolationException, OptimisticLockingException, AbfrageStatusNotAllowedException, BauvorhabenNotReferencedException {
         final var abfrage = this.getInfrastrukturabfrageById(abfrageId);
         this.throwAbfrageStatusNotAllowedExceptionWhenStatusAbfrageIsInvalid(
                 abfrage.getAbfrage(),
                 StatusAbfrage.IN_BEARBEITUNG_SACHBEARBEITUNG
-            );
+        );
         final var abfragevariante = Stream
-            .concat(
-                CollectionUtils.emptyIfNull(abfrage.getAbfragevarianten()).stream(),
-                CollectionUtils.emptyIfNull(abfrage.getAbfragevariantenSachbearbeitung()).stream()
-            )
-            .filter(abfragevarianteModel -> abfragevarianteModel.getId().equals(abfragevarianteId))
-            .findFirst()
-            .orElseThrow(() -> {
-                final var message = "Abfragevariante wurde nicht gefunden";
-                log.error(message);
-                return new EntityNotFoundException(message);
-            });
+                .concat(
+                        CollectionUtils.emptyIfNull(abfrage.getAbfragevarianten()).stream(),
+                        CollectionUtils.emptyIfNull(abfrage.getAbfragevariantenSachbearbeitung()).stream()
+                )
+                .filter(abfragevarianteModel -> abfragevarianteModel.getId().equals(abfragevarianteId))
+                .findFirst()
+                .orElseThrow(() -> {
+                    final var message = "Abfragevariante wurde nicht gefunden";
+                    log.error(message);
+                    return new EntityNotFoundException(message);
+                });
         if (abfragevariante.isRelevant()) {
             abfragevariante.setRelevant(false);
         } else {
@@ -222,7 +223,7 @@ public class AbfrageService {
      * @throws OptimisticLockingException falls in der Anwendung bereits eine neuere Version der Entität gespeichert ist
      */
     public InfrastrukturabfrageModel changeStatusAbfrage(final UUID id, final StatusAbfrage statusAbfrage)
-        throws EntityNotFoundException, UniqueViolationException, OptimisticLockingException {
+            throws EntityNotFoundException, UniqueViolationException, OptimisticLockingException {
         final var originalAbfrageDb = this.getInfrastrukturabfrageById(id);
         originalAbfrageDb.getAbfrage().setStatusAbfrage(statusAbfrage);
         return this.saveInfrastrukturabfrage(originalAbfrageDb);
@@ -238,13 +239,15 @@ public class AbfrageService {
      * @throws AbfrageStatusNotAllowedException falls die Abfrage den falschen Status hat..
      */
     public void deleteInfrasturkturabfrageById(final UUID id)
-        throws EntityNotFoundException, EntityIsReferencedException, UserRoleNotAllowedException, AbfrageStatusNotAllowedException {
+            throws EntityNotFoundException, EntityIsReferencedException, UserRoleNotAllowedException, AbfrageStatusNotAllowedException {
         final var abfrage = this.getInfrastrukturabfrageById(id);
         if (abfrage.getSub() == authenticationUtils.getUserSub()) {
             this.throwUserRoleNotAllowedOrAbfrageStatusNotAlloweExceptionWhenDeleteAbfrage(abfrage.getAbfrage());
             this.throwEntityIsReferencedExceptionWhenAbfrageIsReferencingBauvorhaben(abfrage.getAbfrage());
             this.infrastrukturabfrageRepository.deleteById(id);
         } else {
+            log.error(abfrage.getSub());
+            log.error(authenticationUtils.getUserSub());
             throw new UserRoleNotAllowedException("Keine Berechtigung zum Löschen der Abfrage");
         }
     }
@@ -257,14 +260,14 @@ public class AbfrageService {
      * @throws AbfrageStatusNotAllowedException falls die Abfrage den falschen Status hat..
      */
     public void throwUserRoleNotAllowedOrAbfrageStatusNotAlloweExceptionWhenDeleteAbfrage(AbfrageModel abfrage)
-        throws UserRoleNotAllowedException, AbfrageStatusNotAllowedException {
+            throws UserRoleNotAllowedException, AbfrageStatusNotAllowedException {
         var roles = authenticationUtils.getUserRoles();
         if (!roles.contains("admin")) {
             if (!roles.contains("abfrageerstellung")) {
                 throw new UserRoleNotAllowedException("Keine Berechtigung zum Löschen der Abfrage");
             } else if (abfrage.getStatusAbfrage() != StatusAbfrage.ANGELEGT) {
                 throw new AbfrageStatusNotAllowedException(
-                    "Die Abfrage kann im nur im Status 'angelegt' gelöscht werden."
+                        "Die Abfrage kann im nur im Status 'angelegt' gelöscht werden."
                 );
             }
         }
@@ -278,15 +281,15 @@ public class AbfrageService {
      * @throws EntityIsReferencedException falls das {@link AbfrageModel} ein {@link BauvorhabenModel} referenziert.
      */
     protected void throwEntityIsReferencedExceptionWhenAbfrageIsReferencingBauvorhaben(final AbfrageModel abfrage)
-        throws EntityIsReferencedException {
+            throws EntityIsReferencedException {
         final var bauvorhaben = abfrage.getBauvorhaben();
         if (ObjectUtils.isNotEmpty(bauvorhaben)) {
             final var message =
-                "Die Abfrage " +
-                abfrage.getNameAbfrage() +
-                " referenziert das Bauvorhaben " +
-                bauvorhaben.getNameVorhaben() +
-                ".";
+                    "Die Abfrage " +
+                            abfrage.getNameAbfrage() +
+                            " referenziert das Bauvorhaben " +
+                            bauvorhaben.getNameVorhaben() +
+                            ".";
             log.error(message);
             throw new EntityIsReferencedException(message);
         }
@@ -301,18 +304,18 @@ public class AbfrageService {
      * @throws AbfrageStatusNotAllowedException falls das {@link AbfrageModel} einen unzulässigen Status hat
      */
     protected void throwAbfrageStatusNotAllowedExceptionWhenStatusAbfrageIsInvalid(
-        final AbfrageModel abfrage,
-        final StatusAbfrage statusAbfrage
+            final AbfrageModel abfrage,
+            final StatusAbfrage statusAbfrage
     ) throws AbfrageStatusNotAllowedException {
         if (abfrage.getStatusAbfrage() != statusAbfrage) {
             final var message =
-                "Die Abfrage " +
-                abfrage.getNameAbfrage() +
-                " ist im Status " +
-                abfrage.getStatusAbfrage().toString() +
-                ". Der gültige Status wäre " +
-                statusAbfrage.toString() +
-                ".";
+                    "Die Abfrage " +
+                            abfrage.getNameAbfrage() +
+                            " ist im Status " +
+                            abfrage.getStatusAbfrage().toString() +
+                            ". Der gültige Status wäre " +
+                            statusAbfrage.toString() +
+                            ".";
             log.error(message);
             throw new AbfrageStatusNotAllowedException(message);
         }
@@ -327,11 +330,11 @@ public class AbfrageService {
      */
 
     private void throwsBauvorhabenNotReferencedExceptionOrUniqueViolationExceptionIfRelevant(
-        final InfrastrukturabfrageModel abfrage
+            final InfrastrukturabfrageModel abfrage
     ) throws UniqueViolationException, BauvorhabenNotReferencedException {
         if (abfrage.getAbfrage().getBauvorhaben() == null) {
             String message =
-                "Die Abfrage ist keinem Bauvorhaben zugeordnet. Somit kann keine Abfragevariante als relevant markiert werden.";
+                    "Die Abfrage ist keinem Bauvorhaben zugeordnet. Somit kann keine Abfragevariante als relevant markiert werden.";
             log.error(message);
             throw new BauvorhabenNotReferencedException(message);
         }
@@ -339,28 +342,28 @@ public class AbfrageService {
         final var nameRelevantAbfrage = new StringBuilder();
         final var nameRelevantAbfragevariante = new StringBuilder();
         this.infrastrukturabfrageRepository.findAllByAbfrageBauvorhabenId(abfrage.getAbfrage().getBauvorhaben().getId())
-            .forEach(infrastrukturabfrage -> {
-                Stream
-                    .concat(
-                        CollectionUtils.emptyIfNull(infrastrukturabfrage.getAbfragevarianten()).stream(),
-                        CollectionUtils.emptyIfNull(infrastrukturabfrage.getAbfragevariantenSachbearbeitung()).stream()
-                    )
-                    .forEach(abfragevariante -> {
-                        if (abfragevariante.isRelevant()) {
-                            relevanteAbfrage.set(true);
-                            nameRelevantAbfrage.append(infrastrukturabfrage.getAbfrage().getNameAbfrage());
-                            nameRelevantAbfragevariante.append(abfragevariante.getAbfragevariantenName());
-                        }
-                    });
-            });
+                .forEach(infrastrukturabfrage -> {
+                    Stream
+                            .concat(
+                                    CollectionUtils.emptyIfNull(infrastrukturabfrage.getAbfragevarianten()).stream(),
+                                    CollectionUtils.emptyIfNull(infrastrukturabfrage.getAbfragevariantenSachbearbeitung()).stream()
+                            )
+                            .forEach(abfragevariante -> {
+                                if (abfragevariante.isRelevant()) {
+                                    relevanteAbfrage.set(true);
+                                    nameRelevantAbfrage.append(infrastrukturabfrage.getAbfrage().getNameAbfrage());
+                                    nameRelevantAbfragevariante.append(abfragevariante.getAbfragevariantenName());
+                                }
+                            });
+                });
 
         if (relevanteAbfrage.get()) {
             var errorMessage =
-                "Die Abfragevariante " +
-                nameRelevantAbfragevariante +
-                " in Abfrage " +
-                nameRelevantAbfrage +
-                " ist bereits als relevant markiert.";
+                    "Die Abfragevariante " +
+                            nameRelevantAbfragevariante +
+                            " in Abfrage " +
+                            nameRelevantAbfrage +
+                            " ist bereits als relevant markiert.";
             log.error(errorMessage);
             throw new UniqueViolationException(errorMessage);
         }

--- a/src/main/java/de/muenchen/isi/domain/service/AbfrageService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/AbfrageService.java
@@ -87,6 +87,7 @@ public class AbfrageService {
         throws UniqueViolationException, OptimisticLockingException {
         if (abfrage.getId() == null) {
             abfrage.getAbfrage().setStatusAbfrage(StatusAbfrage.ANGELEGT);
+            abfrage.setSub(authenticationUtils.getUserSub());
         }
         var abfrageEntity = this.abfrageDomainMapper.model2entity(abfrage);
         final var saved =
@@ -239,9 +240,13 @@ public class AbfrageService {
     public void deleteInfrasturkturabfrageById(final UUID id)
         throws EntityNotFoundException, EntityIsReferencedException, UserRoleNotAllowedException, AbfrageStatusNotAllowedException {
         final var abfrage = this.getInfrastrukturabfrageById(id);
-        this.throwUserRoleNotAllowedOrAbfrageStatusNotAlloweExceptionWhenDeleteAbfrage(abfrage.getAbfrage());
-        this.throwEntityIsReferencedExceptionWhenAbfrageIsReferencingBauvorhaben(abfrage.getAbfrage());
-        this.infrastrukturabfrageRepository.deleteById(id);
+        if (abfrage.getSub() == authenticationUtils.getUserSub()) {
+            this.throwUserRoleNotAllowedOrAbfrageStatusNotAlloweExceptionWhenDeleteAbfrage(abfrage.getAbfrage());
+            this.throwEntityIsReferencedExceptionWhenAbfrageIsReferencingBauvorhaben(abfrage.getAbfrage());
+            this.infrastrukturabfrageRepository.deleteById(id);
+        } else {
+            throw new UserRoleNotAllowedException("Keine Berechtigung zum Löschen der Abfrage");
+        }
     }
 
     /**

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/Infrastrukturabfrage.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/Infrastrukturabfrage.java
@@ -32,6 +32,9 @@ public class Infrastrukturabfrage extends BaseEntity {
     @Embedded
     public Abfrage abfrage;
 
+    @Column(nullable = false)
+    private String sub;
+
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(255) not null check (sobon_relevant != 'UNSPECIFIED')")
     private UncertainBoolean sobonRelevant;

--- a/src/main/java/de/muenchen/isi/security/AuthenticationUtils.java
+++ b/src/main/java/de/muenchen/isi/security/AuthenticationUtils.java
@@ -2,9 +2,6 @@ package de.muenchen.isi.security;
 
 import com.nimbusds.jose.shaded.json.JSONArray;
 import com.nimbusds.jose.shaded.json.JSONObject;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.ObjectUtils;
@@ -16,6 +13,10 @@ import org.springframework.security.oauth2.core.DefaultOAuth2AuthenticatedPrinci
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 @Slf4j
 @Service
 public class AuthenticationUtils {
@@ -26,7 +27,7 @@ public class AuthenticationUtils {
 
     private static final String TOKEN_USER_SUB = "sub";
 
-    private static final String SUB_UNAUTHENTICATED_USER = "4c3c4d2a-e19f-4c7a-8b31-11b92dd3cf67";
+    private static final String SUB_UNAUTHENTICATED_USER = "123456789";
 
     private static final String TOKEN_RESOURCE_ACCESS = "resource_access";
 
@@ -45,7 +46,7 @@ public class AuthenticationUtils {
         if (!ObjectUtils.isEmpty(authentication)) {
             try {
                 final DefaultOAuth2AuthenticatedPrincipal principal =
-                    (DefaultOAuth2AuthenticatedPrincipal) authentication.getPrincipal();
+                        (DefaultOAuth2AuthenticatedPrincipal) authentication.getPrincipal();
                 if (!ObjectUtils.isEmpty(principal)) {
                     for (GrantedAuthority authority : principal.getAuthorities()) {
                         if (EnumUtils.isValidEnum(AuthoritiesEnum.class, authority.getAuthority())) {
@@ -83,14 +84,14 @@ public class AuthenticationUtils {
     /**
      * Die Methode extrahiert den Nutzernamen aus dem im SecurityContext vorhandenen {@link Jwt}.
      *
-     * @return den Nutzernamen oder einen Platzhalter fall kein {@link Jwt} verfügbar
+     * @return den Nutzernamen oder einen Platzhalter falls kein {@link Jwt} verfügbar
      */
     public String getUserSub() {
         String sub = null;
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (!ObjectUtils.isEmpty(authentication)) {
             final DefaultOAuth2AuthenticatedPrincipal principal =
-                (DefaultOAuth2AuthenticatedPrincipal) authentication.getPrincipal();
+                    (DefaultOAuth2AuthenticatedPrincipal) authentication.getPrincipal();
             if (!ObjectUtils.isEmpty(principal)) {
                 sub = principal.getAttribute(TOKEN_USER_SUB).toString();
             }
@@ -108,7 +109,7 @@ public class AuthenticationUtils {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (!ObjectUtils.isEmpty(authentication)) {
             final DefaultOAuth2AuthenticatedPrincipal principal =
-                (DefaultOAuth2AuthenticatedPrincipal) authentication.getPrincipal();
+                    (DefaultOAuth2AuthenticatedPrincipal) authentication.getPrincipal();
             if (!ObjectUtils.isEmpty(principal)) {
                 JSONObject resourceAccess = principal.getAttribute(TOKEN_RESOURCE_ACCESS);
                 if (!resourceAccess.isEmpty()) {

--- a/src/main/java/de/muenchen/isi/security/AuthenticationUtils.java
+++ b/src/main/java/de/muenchen/isi/security/AuthenticationUtils.java
@@ -24,6 +24,16 @@ public class AuthenticationUtils {
 
     private static final String TOKEN_USER_NAME = "username";
 
+    private static final String TOKEN_USER_SUB = "sub";
+
+    private static final String SUB_UNAUTHENTICATED_USER = "4c3c4d2a-e19f-4c7a-8b31-11b92dd3cf67";
+
+    private static final String TOKEN_RESOURCE_ACCESS = "resource_access";
+
+    private static final String TOKEN_ISI = "isi";
+
+    private static final String TOKEN_ROLES = "roles";
+
     /**
      * Die Methode extrahiert die Authorities des Nutzers aus dem {@link DefaultOAuth2AuthenticatedPrincipal}
      *
@@ -71,6 +81,24 @@ public class AuthenticationUtils {
     }
 
     /**
+     * Die Methode extrahiert den Nutzernamen aus dem im SecurityContext vorhandenen {@link Jwt}.
+     *
+     * @return den Nutzernamen oder einen Platzhalter fall kein {@link Jwt} verfügbar
+     */
+    public String getUserSub() {
+        String sub = null;
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (!ObjectUtils.isEmpty(authentication)) {
+            final DefaultOAuth2AuthenticatedPrincipal principal =
+                (DefaultOAuth2AuthenticatedPrincipal) authentication.getPrincipal();
+            if (!ObjectUtils.isEmpty(principal)) {
+                sub = principal.getAttribute(TOKEN_USER_SUB).toString();
+            }
+        }
+        return StringUtils.isNotBlank(sub) ? sub : SUB_UNAUTHENTICATED_USER;
+    }
+
+    /**
      * Die Methode extrahiert die Nutzerrollen des Nutzers aus dem {@link DefaultOAuth2AuthenticatedPrincipal}
      *
      * @return Liste der Nutzerrollen des Nutzers
@@ -82,11 +110,11 @@ public class AuthenticationUtils {
             final DefaultOAuth2AuthenticatedPrincipal principal =
                 (DefaultOAuth2AuthenticatedPrincipal) authentication.getPrincipal();
             if (!ObjectUtils.isEmpty(principal)) {
-                JSONObject resourceAccess = principal.getAttribute("resource_access");
+                JSONObject resourceAccess = principal.getAttribute(TOKEN_RESOURCE_ACCESS);
                 if (!resourceAccess.isEmpty()) {
-                    JSONObject isi = (JSONObject) resourceAccess.get("isi");
+                    JSONObject isi = (JSONObject) resourceAccess.get(TOKEN_ISI);
                     if (!isi.isEmpty()) {
-                        JSONArray rolesArray = (JSONArray) isi.get("roles");
+                        JSONArray rolesArray = (JSONArray) isi.get(TOKEN_ROLES);
                         if (!rolesArray.isEmpty()) {
                             rolesArray.forEach(role -> roles.add(role.toString()));
                         }

--- a/src/test/java/de/muenchen/isi/domain/service/AbfrageServiceTest.java
+++ b/src/test/java/de/muenchen/isi/domain/service/AbfrageServiceTest.java
@@ -1,8 +1,5 @@
 package de.muenchen.isi.domain.service;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
 import de.muenchen.isi.domain.exception.AbfrageStatusNotAllowedException;
 import de.muenchen.isi.domain.exception.BauvorhabenNotReferencedException;
 import de.muenchen.isi.domain.exception.EntityIsReferencedException;
@@ -37,10 +34,6 @@ import de.muenchen.isi.infrastructure.entity.Infrastrukturabfrage;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusAbfrage;
 import de.muenchen.isi.infrastructure.repository.InfrastrukturabfrageRepository;
 import de.muenchen.isi.security.AuthenticationUtils;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,15 +46,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 @ExtendWith(SpringExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ContextConfiguration(
-    classes = {
-        AbfrageDomainMapperImpl.class,
-        AbfragevarianteDomainMapperImpl.class,
-        BauabschnittDomainMapperImpl.class,
-        DokumentDomainMapperImpl.class,
-    }
+        classes = {
+                AbfrageDomainMapperImpl.class,
+                AbfragevarianteDomainMapperImpl.class,
+                BauabschnittDomainMapperImpl.class,
+                DokumentDomainMapperImpl.class,
+        }
 )
 class AbfrageServiceTest {
 
@@ -91,12 +92,12 @@ class AbfrageServiceTest {
     @BeforeEach
     public void beforeEach() {
         this.abfrageService =
-        new AbfrageService(
-            this.abfrageDomainMapper,
-            this.infrastrukturabfrageRepository,
-            this.dokumentService,
-            this.authenticationUtils
-        );
+                new AbfrageService(
+                        this.abfrageDomainMapper,
+                        this.infrastrukturabfrageRepository,
+                        this.dokumentService,
+                        this.authenticationUtils
+                );
         Mockito.reset(this.infrastrukturabfrageRepository, this.dokumentService);
     }
 
@@ -108,8 +109,8 @@ class AbfrageServiceTest {
         entity2.setId(UUID.randomUUID());
 
         Mockito
-            .when(this.infrastrukturabfrageRepository.findAllByOrderByAbfrageFristStellungnahmeDesc())
-            .thenReturn(Stream.of(entity1, entity2));
+                .when(this.infrastrukturabfrageRepository.findAllByOrderByAbfrageFristStellungnahmeDesc())
+                .thenReturn(Stream.of(entity1, entity2));
 
         final List<InfrastrukturabfrageModel> result = this.abfrageService.getInfrastrukturabfragen();
 
@@ -126,8 +127,8 @@ class AbfrageServiceTest {
         final UUID id = UUID.randomUUID();
 
         Mockito
-            .when(this.infrastrukturabfrageRepository.findById(id))
-            .thenReturn(Optional.of(new Infrastrukturabfrage()));
+                .when(this.infrastrukturabfrageRepository.findById(id))
+                .thenReturn(Optional.of(new Infrastrukturabfrage()));
         final InfrastrukturabfrageModel result = this.abfrageService.getInfrastrukturabfrageById(id);
         assertThat(result, is((new InfrastrukturabfrageModel())));
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).findById(id);
@@ -135,8 +136,8 @@ class AbfrageServiceTest {
 
         Mockito.when(this.infrastrukturabfrageRepository.findById(id)).thenReturn(Optional.empty());
         Assertions.assertThrows(
-            EntityNotFoundException.class,
-            () -> this.abfrageService.getInfrastrukturabfrageById(id)
+                EntityNotFoundException.class,
+                () -> this.abfrageService.getInfrastrukturabfrageById(id)
         );
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).findById(id);
     }
@@ -165,11 +166,11 @@ class AbfrageServiceTest {
         Mockito.when(this.authenticationUtils.getUserSub()).thenReturn(sub);
         Mockito.when(this.infrastrukturabfrageRepository.saveAndFlush(abfrageEntity)).thenReturn(saveResult);
         Mockito
-            .when(this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase("hallo"))
-            .thenReturn(Optional.empty());
+                .when(this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase("hallo"))
+                .thenReturn(Optional.empty());
 
         final InfrastrukturabfrageModel result =
-            this.abfrageService.saveInfrastrukturabfrage(infrastrukturabfrageModel);
+                this.abfrageService.saveInfrastrukturabfrage(infrastrukturabfrageModel);
 
         final InfrastrukturabfrageModel expected = new InfrastrukturabfrageModel();
         expected.setId(saveResult.getId());
@@ -182,8 +183,8 @@ class AbfrageServiceTest {
         assertThat(result, is(expected));
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).saveAndFlush(abfrageEntity);
         Mockito
-            .verify(this.infrastrukturabfrageRepository, Mockito.times(1))
-            .findByAbfrage_NameAbfrageIgnoreCase("hallo");
+                .verify(this.infrastrukturabfrageRepository, Mockito.times(1))
+                .findByAbfrage_NameAbfrageIgnoreCase("hallo");
     }
 
     @Test
@@ -218,14 +219,14 @@ class AbfrageServiceTest {
         Mockito.when(this.authenticationUtils.getUserSub()).thenReturn(sub);
 
         Mockito
-            .when(this.infrastrukturabfrageRepository.saveAndFlush(infrastrukturabfrageEntity))
-            .thenReturn(saveResult);
+                .when(this.infrastrukturabfrageRepository.saveAndFlush(infrastrukturabfrageEntity))
+                .thenReturn(saveResult);
         Mockito
-            .when(this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase("hallo"))
-            .thenReturn(Optional.empty());
+                .when(this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase("hallo"))
+                .thenReturn(Optional.empty());
 
         final InfrastrukturabfrageModel result =
-            this.abfrageService.saveInfrastrukturabfrage(infrastrukturabfrageModel);
+                this.abfrageService.saveInfrastrukturabfrage(infrastrukturabfrageModel);
 
         final InfrastrukturabfrageModel expected = new InfrastrukturabfrageModel();
         expected.setId(saveResult.getId());
@@ -238,8 +239,8 @@ class AbfrageServiceTest {
         assertThat(result, is(expected));
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).saveAndFlush(infrastrukturabfrageEntity);
         Mockito
-            .verify(this.infrastrukturabfrageRepository, Mockito.times(1))
-            .findByAbfrage_NameAbfrageIgnoreCase("hallo");
+                .verify(this.infrastrukturabfrageRepository, Mockito.times(1))
+                .findByAbfrage_NameAbfrageIgnoreCase("hallo");
     }
 
     @Test
@@ -258,27 +259,27 @@ class AbfrageServiceTest {
 
         Mockito.when(this.infrastrukturabfrageRepository.saveAndFlush(abfrageEntity)).thenReturn(abfrageEntity);
         Mockito
-            .when(this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase("hallo"))
-            .thenReturn(Optional.of(abfrageEntity));
+                .when(this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase("hallo"))
+                .thenReturn(Optional.of(abfrageEntity));
 
         Assertions.assertThrows(
-            UniqueViolationException.class,
-            () -> this.abfrageService.saveInfrastrukturabfrage(infrastrukturabfrageModel2)
+                UniqueViolationException.class,
+                () -> this.abfrageService.saveInfrastrukturabfrage(infrastrukturabfrageModel2)
         );
 
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(0)).saveAndFlush(abfrageEntity);
         Mockito
-            .verify(this.infrastrukturabfrageRepository, Mockito.times(1))
-            .findByAbfrage_NameAbfrageIgnoreCase("hallo");
+                .verify(this.infrastrukturabfrageRepository, Mockito.times(1))
+                .findByAbfrage_NameAbfrageIgnoreCase("hallo");
     }
 
     @Test
     void patchAbfrageAngelegt()
-        throws EntityNotFoundException, UniqueViolationException, OptimisticLockingException, AbfrageStatusNotAllowedException, FileHandlingFailedException, FileHandlingWithS3FailedException {
+            throws EntityNotFoundException, UniqueViolationException, OptimisticLockingException, AbfrageStatusNotAllowedException, FileHandlingFailedException, FileHandlingWithS3FailedException {
         final UUID abfrageId = UUID.randomUUID();
 
         final InfrastrukturabfrageAngelegtModel infrastrukturabfrageRequestModel =
-            new InfrastrukturabfrageAngelegtModel();
+                new InfrastrukturabfrageAngelegtModel();
 
         final AbfrageAngelegtModel abfrageRequestModel = new AbfrageAngelegtModel();
         abfrageRequestModel.setNameAbfrage("hallo");
@@ -296,36 +297,36 @@ class AbfrageServiceTest {
         infrastrukturabfrageModel.setAbfrage(abfrageModel);
 
         final InfrastrukturabfrageModel infrastrukturabfrageModelMapped =
-            this.abfrageDomainMapper.request2Model(infrastrukturabfrageRequestModel, infrastrukturabfrageModel);
+                this.abfrageDomainMapper.request2Model(infrastrukturabfrageRequestModel, infrastrukturabfrageModel);
         final Infrastrukturabfrage entity = this.abfrageDomainMapper.model2entity(infrastrukturabfrageModelMapped);
 
         Mockito.when(this.infrastrukturabfrageRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
         Mockito.when(this.infrastrukturabfrageRepository.saveAndFlush(entity)).thenReturn(entity);
         Mockito
-            .when(this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase("hallo"))
-            .thenReturn(Optional.empty());
+                .when(this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase("hallo"))
+                .thenReturn(Optional.empty());
 
         final InfrastrukturabfrageModel result =
-            this.abfrageService.patchAbfrageAngelegt(infrastrukturabfrageRequestModel, entity.getId());
+                this.abfrageService.patchAbfrageAngelegt(infrastrukturabfrageRequestModel, entity.getId());
 
         assertThat(result, is(infrastrukturabfrageModel));
 
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).findById(entity.getId());
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).saveAndFlush(entity);
         Mockito
-            .verify(this.infrastrukturabfrageRepository, Mockito.times(1))
-            .findByAbfrage_NameAbfrageIgnoreCase("hallo");
+                .verify(this.infrastrukturabfrageRepository, Mockito.times(1))
+                .findByAbfrage_NameAbfrageIgnoreCase("hallo");
         Mockito
-            .verify(this.dokumentService, Mockito.times(1))
-            .deleteDokumenteFromOriginalDokumentenListWhichAreMissingInParameterAdaptedDokumentenListe(
-                Mockito.isNull(),
-                Mockito.isNull()
-            );
+                .verify(this.dokumentService, Mockito.times(1))
+                .deleteDokumenteFromOriginalDokumentenListWhichAreMissingInParameterAdaptedDokumentenListe(
+                        Mockito.isNull(),
+                        Mockito.isNull()
+                );
     }
 
     @Test
     void patchAbfrageInBearbeitungSachbearbeitung()
-        throws UniqueViolationException, OptimisticLockingException, EntityNotFoundException, AbfrageStatusNotAllowedException {
+            throws UniqueViolationException, OptimisticLockingException, EntityNotFoundException, AbfrageStatusNotAllowedException {
         final var uuid = UUID.randomUUID();
 
         final var infrastrukturabfrageRequestModel = new InfrastrukturabfrageInBearbeitungSachbearbeitungModel();
@@ -346,8 +347,8 @@ class AbfrageServiceTest {
         entityInDb.setAbfrage(abfrage);
 
         Mockito
-            .when(this.infrastrukturabfrageRepository.findById(entityInDb.getId()))
-            .thenReturn(Optional.of(entityInDb));
+                .when(this.infrastrukturabfrageRepository.findById(entityInDb.getId()))
+                .thenReturn(Optional.of(entityInDb));
 
         final var entityToSave = new Infrastrukturabfrage();
         entityToSave.setAbfragevarianten(List.of());
@@ -377,11 +378,11 @@ class AbfrageServiceTest {
 
         Mockito.when(this.infrastrukturabfrageRepository.saveAndFlush(entityToSave)).thenReturn(entitySaved);
         Mockito
-            .when(this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase("hallo"))
-            .thenReturn(Optional.empty());
+                .when(this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase("hallo"))
+                .thenReturn(Optional.empty());
 
         final var result =
-            this.abfrageService.patchAbfrageInBearbeitungSachbearbeitung(infrastrukturabfrageRequestModel, uuid);
+                this.abfrageService.patchAbfrageInBearbeitungSachbearbeitung(infrastrukturabfrageRequestModel, uuid);
 
         final var entityExpected = new InfrastrukturabfrageModel();
         entityExpected.setId(uuid);
@@ -401,7 +402,7 @@ class AbfrageServiceTest {
 
     @Test
     void changeAbfragevarianteRelevant()
-        throws EntityNotFoundException, UniqueViolationException, OptimisticLockingException, AbfrageStatusNotAllowedException, FileHandlingFailedException, FileHandlingWithS3FailedException, BauvorhabenNotReferencedException {
+            throws EntityNotFoundException, UniqueViolationException, OptimisticLockingException, AbfrageStatusNotAllowedException, FileHandlingFailedException, FileHandlingWithS3FailedException, BauvorhabenNotReferencedException {
         final UUID abfrageId = UUID.randomUUID();
         final UUID abfragevarianteId = UUID.randomUUID();
         final UUID bauvorhabenId = UUID.randomUUID();
@@ -443,29 +444,29 @@ class AbfrageServiceTest {
 
         Mockito.when(this.infrastrukturabfrageRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
         Mockito
-            .when(this.infrastrukturabfrageRepository.saveAndFlush(infrastrukturabfrageEntity))
-            .thenReturn(infrastrukturabfrageEntity);
+                .when(this.infrastrukturabfrageRepository.saveAndFlush(infrastrukturabfrageEntity))
+                .thenReturn(infrastrukturabfrageEntity);
         Mockito
-            .when(this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase("hallo"))
-            .thenReturn(Optional.empty());
+                .when(this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase("hallo"))
+                .thenReturn(Optional.empty());
 
         final InfrastrukturabfrageModel result =
-            this.abfrageService.changeAbfragevarianteRelevant(abfrageId, abfragevarianteId);
+                this.abfrageService.changeAbfragevarianteRelevant(abfrageId, abfragevarianteId);
 
         assertThat(result.getAbfragevarianten().get(0).isRelevant(), is(true));
 
         Mockito
-            .verify(this.infrastrukturabfrageRepository, Mockito.times(1))
-            .findById(infrastrukturabfrageEntity.getId());
+                .verify(this.infrastrukturabfrageRepository, Mockito.times(1))
+                .findById(infrastrukturabfrageEntity.getId());
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).saveAndFlush(infrastrukturabfrageEntity);
         Mockito
-            .verify(this.infrastrukturabfrageRepository, Mockito.times(1))
-            .findByAbfrage_NameAbfrageIgnoreCase("hallo");
+                .verify(this.infrastrukturabfrageRepository, Mockito.times(1))
+                .findByAbfrage_NameAbfrageIgnoreCase("hallo");
     }
 
     @Test
     void changeAbfragevarianteRelevantUniqueViolationTest()
-        throws UniqueViolationException, OptimisticLockingException {
+            throws UniqueViolationException, OptimisticLockingException {
         final UUID abfrageId_1 = UUID.randomUUID();
         final UUID abfrageId_2 = UUID.randomUUID();
 
@@ -510,14 +511,14 @@ class AbfrageServiceTest {
         Mockito.when(this.infrastrukturabfrageRepository.findById(entity_2.getId())).thenReturn(Optional.of(entity_2));
 
         Mockito
-            .when(this.infrastrukturabfrageRepository.findAllByAbfrageBauvorhabenId(bauvorhabenModel.getId()))
-            .thenReturn(Stream.of(entity_1, entity_2));
+                .when(this.infrastrukturabfrageRepository.findAllByAbfrageBauvorhabenId(bauvorhabenModel.getId()))
+                .thenReturn(Stream.of(entity_1, entity_2));
 
         this.abfrageService.saveInfrastrukturabfrage(infrastrukturabfrage_1);
 
         Assertions.assertThrows(
-            UniqueViolationException.class,
-            () -> this.abfrageService.changeAbfragevarianteRelevant(abfrageId_2, abfragevariante_2.getId())
+                UniqueViolationException.class,
+                () -> this.abfrageService.changeAbfragevarianteRelevant(abfrageId_2, abfragevariante_2.getId())
         );
 
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).saveAndFlush(entity_1);
@@ -545,18 +546,18 @@ class AbfrageServiceTest {
         Mockito.when(this.infrastrukturabfrageRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
 
         Assertions.assertThrows(
-            BauvorhabenNotReferencedException.class,
-            () -> this.abfrageService.changeAbfragevarianteRelevant(abfrageId, abfragevariante.getId())
+                BauvorhabenNotReferencedException.class,
+                () -> this.abfrageService.changeAbfragevarianteRelevant(abfrageId, abfragevariante.getId())
         );
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).findById(entity.getId());
     }
 
     @Test
     void throwAbfrageStatusNotAllowedExceptionWhenStatusAbfrageIsInvalid()
-        throws EntityNotFoundException, UniqueViolationException, OptimisticLockingException, AbfrageStatusNotAllowedException, FileHandlingFailedException, FileHandlingWithS3FailedException {
+            throws EntityNotFoundException, UniqueViolationException, OptimisticLockingException, AbfrageStatusNotAllowedException, FileHandlingFailedException, FileHandlingWithS3FailedException {
         final UUID abfrageId = UUID.randomUUID();
         final InfrastrukturabfrageAngelegtModel infrastrukturabfrageRequestModel =
-            new InfrastrukturabfrageAngelegtModel();
+                new InfrastrukturabfrageAngelegtModel();
         final AbfrageAngelegtModel abfrageRequestModel = new AbfrageAngelegtModel();
         abfrageRequestModel.setNameAbfrage("test");
         infrastrukturabfrageRequestModel.setAbfrage(abfrageRequestModel);
@@ -571,36 +572,36 @@ class AbfrageServiceTest {
         abfrageModel.setStatusAbfrage(StatusAbfrage.OFFEN);
         infrastrukturabfrageModel.setAbfrage(abfrageModel);
         infrastrukturabfrageModel =
-        this.abfrageDomainMapper.request2Model(infrastrukturabfrageRequestModel, infrastrukturabfrageModel);
+                this.abfrageDomainMapper.request2Model(infrastrukturabfrageRequestModel, infrastrukturabfrageModel);
 
         final Infrastrukturabfrage entity = this.abfrageDomainMapper.model2entity(infrastrukturabfrageModel);
         entity.setId(UUID.randomUUID());
         Mockito.when(this.infrastrukturabfrageRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
 
         Assertions.assertThrows(
-            AbfrageStatusNotAllowedException.class,
-            () -> this.abfrageService.patchAbfrageAngelegt(infrastrukturabfrageRequestModel, entity.getId())
+                AbfrageStatusNotAllowedException.class,
+                () -> this.abfrageService.patchAbfrageAngelegt(infrastrukturabfrageRequestModel, entity.getId())
         );
 
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).findById(entity.getId());
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(0)).saveAndFlush(entity);
         Mockito
-            .verify(this.infrastrukturabfrageRepository, Mockito.times(0))
-            .findByAbfrage_NameAbfrageIgnoreCase("test");
+                .verify(this.infrastrukturabfrageRepository, Mockito.times(0))
+                .findByAbfrage_NameAbfrageIgnoreCase("test");
         Mockito
-            .verify(this.dokumentService, Mockito.times(0))
-            .deleteDokumenteFromOriginalDokumentenListWhichAreMissingInParameterAdaptedDokumentenListe(
-                Mockito.isNull(),
-                Mockito.isNull()
-            );
+                .verify(this.dokumentService, Mockito.times(0))
+                .deleteDokumenteFromOriginalDokumentenListWhichAreMissingInParameterAdaptedDokumentenListe(
+                        Mockito.isNull(),
+                        Mockito.isNull()
+                );
     }
 
     @Test
     void deleteInfrastrukturabfrageAbfrageerstellung()
-        throws EntityNotFoundException, EntityIsReferencedException, UserRoleNotAllowedException, AbfrageStatusNotAllowedException {
+            throws EntityNotFoundException, EntityIsReferencedException, UserRoleNotAllowedException, AbfrageStatusNotAllowedException {
         final UUID id = UUID.randomUUID();
 
-        String[] roles = { "abfrageerstellung" };
+        String[] roles = {"abfrageerstellung"};
         String sub = "1234";
 
         final Infrastrukturabfrage entity = new Infrastrukturabfrage();
@@ -624,10 +625,10 @@ class AbfrageServiceTest {
 
     @Test
     void deleteInfrastrukturabfrageAdmin()
-        throws EntityNotFoundException, EntityIsReferencedException, UserRoleNotAllowedException, AbfrageStatusNotAllowedException {
+            throws EntityNotFoundException, EntityIsReferencedException, UserRoleNotAllowedException, AbfrageStatusNotAllowedException {
         final UUID id = UUID.randomUUID();
 
-        String[] roles = { "admin" };
+        String[] roles = {"admin"};
         String sub = "1234";
 
         final Infrastrukturabfrage entity = new Infrastrukturabfrage();
@@ -652,7 +653,7 @@ class AbfrageServiceTest {
     @Test
     void deleteInfrastrukturabfrageUserNotAllowedException() {
         final UUID id = UUID.randomUUID();
-        String[] roles = { "abfrageerstellung" };
+        String[] roles = {"abfrageerstellung"};
         String sub = "1234";
         final Infrastrukturabfrage entity = new Infrastrukturabfrage();
         entity.setId(id);
@@ -666,8 +667,8 @@ class AbfrageServiceTest {
         Mockito.when(this.authenticationUtils.getUserSub()).thenReturn(sub);
 
         Assertions.assertThrows(
-            UserRoleNotAllowedException.class,
-            () -> this.abfrageService.deleteInfrasturkturabfrageById(id)
+                UserRoleNotAllowedException.class,
+                () -> this.abfrageService.deleteInfrasturkturabfrageById(id)
         );
 
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).findById(entity.getId());
@@ -677,9 +678,11 @@ class AbfrageServiceTest {
     @Test
     void deleteInfrastrukturabfrageException() {
         final UUID id = UUID.randomUUID();
-        String[] roles = { "abfrageerstellung" };
+        String[] roles = {"abfrageerstellung"};
+        String sub = "1234";
         final Infrastrukturabfrage entity = new Infrastrukturabfrage();
         entity.setId(id);
+        entity.setSub(sub);
         final Abfrage abfrage = new Abfrage();
         abfrage.setBauvorhaben(new Bauvorhaben());
         abfrage.setStatusAbfrage(StatusAbfrage.ANGELEGT);
@@ -687,10 +690,11 @@ class AbfrageServiceTest {
 
         Mockito.when(this.infrastrukturabfrageRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
         Mockito.when(this.authenticationUtils.getUserRoles()).thenReturn(List.of(roles));
+        Mockito.when(this.authenticationUtils.getUserSub()).thenReturn(sub);
 
         Assertions.assertThrows(
-            EntityIsReferencedException.class,
-            () -> this.abfrageService.deleteInfrasturkturabfrageById(id)
+                EntityIsReferencedException.class,
+                () -> this.abfrageService.deleteInfrasturkturabfrageById(id)
         );
 
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).findById(entity.getId());
@@ -700,19 +704,22 @@ class AbfrageServiceTest {
     @Test
     void deleteInfrastrukturabfrageStatusException() {
         final UUID id = UUID.randomUUID();
-        String[] roles = { "abfrageerstellung" };
+        String[] roles = {"abfrageerstellung"};
+        String sub = "1234";
         final Infrastrukturabfrage entity = new Infrastrukturabfrage();
         entity.setId(id);
+        entity.setSub(sub);
         final Abfrage abfrage = new Abfrage();
         abfrage.setStatusAbfrage(StatusAbfrage.OFFEN);
         entity.setAbfrage(abfrage);
 
         Mockito.when(this.infrastrukturabfrageRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
         Mockito.when(this.authenticationUtils.getUserRoles()).thenReturn(List.of(roles));
+        Mockito.when(this.authenticationUtils.getUserSub()).thenReturn(sub);
 
         Assertions.assertThrows(
-            AbfrageStatusNotAllowedException.class,
-            () -> this.abfrageService.deleteInfrasturkturabfrageById(id)
+                AbfrageStatusNotAllowedException.class,
+                () -> this.abfrageService.deleteInfrasturkturabfrageById(id)
         );
 
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).findById(entity.getId());
@@ -722,19 +729,22 @@ class AbfrageServiceTest {
     @Test
     void deleteInfrastrukturabfrageNutzerException() {
         final UUID id = UUID.randomUUID();
-        String[] roles = { "nutzer" };
+        String[] roles = {"nutzer"};
+        String sub = "1234";
         final Infrastrukturabfrage entity = new Infrastrukturabfrage();
         entity.setId(id);
+        entity.setSub(sub);
         final Abfrage abfrage = new Abfrage();
         abfrage.setStatusAbfrage(StatusAbfrage.ANGELEGT);
         entity.setAbfrage(abfrage);
 
         Mockito.when(this.infrastrukturabfrageRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
         Mockito.when(this.authenticationUtils.getUserRoles()).thenReturn(List.of(roles));
-
+        Mockito.when(this.authenticationUtils.getUserSub()).thenReturn(sub);
+        
         Assertions.assertThrows(
-            UserRoleNotAllowedException.class,
-            () -> this.abfrageService.deleteInfrasturkturabfrageById(id)
+                UserRoleNotAllowedException.class,
+                () -> this.abfrageService.deleteInfrasturkturabfrageById(id)
         );
 
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).findById(entity.getId());
@@ -748,8 +758,8 @@ class AbfrageServiceTest {
         final AbfrageModel abfrage = new AbfrageModel();
         abfrage.setBauvorhaben(new BauvorhabenModel());
         Assertions.assertThrows(
-            EntityIsReferencedException.class,
-            () -> this.abfrageService.throwEntityIsReferencedExceptionWhenAbfrageIsReferencingBauvorhaben(abfrage)
+                EntityIsReferencedException.class,
+                () -> this.abfrageService.throwEntityIsReferencedExceptionWhenAbfrageIsReferencingBauvorhaben(abfrage)
         );
     }
 }

--- a/src/test/java/de/muenchen/isi/domain/service/AbfrageServiceTest.java
+++ b/src/test/java/de/muenchen/isi/domain/service/AbfrageServiceTest.java
@@ -144,6 +144,7 @@ class AbfrageServiceTest {
     @Test
     void saveInfrastrukturabfrage() throws UniqueViolationException, OptimisticLockingException {
         final UUID uuid = UUID.randomUUID();
+        final String sub = "1234";
         final InfrastrukturabfrageModel infrastrukturabfrageModel = new InfrastrukturabfrageModel();
         infrastrukturabfrageModel.setId(uuid);
         final AbfrageModel abfrageModel = new AbfrageModel();
@@ -155,11 +156,13 @@ class AbfrageServiceTest {
 
         final Infrastrukturabfrage saveResult = new Infrastrukturabfrage();
         saveResult.setId(uuid);
+        saveResult.setSub(sub);
         final Abfrage abfrage = new Abfrage();
         abfrage.setNameAbfrage("hallo");
         abfrage.setStatusAbfrage(StatusAbfrage.IN_BEARBEITUNG_SACHBEARBEITUNG);
         saveResult.setAbfrage(abfrage);
 
+        Mockito.when(this.authenticationUtils.getUserSub()).thenReturn(sub);
         Mockito.when(this.infrastrukturabfrageRepository.saveAndFlush(abfrageEntity)).thenReturn(saveResult);
         Mockito
             .when(this.infrastrukturabfrageRepository.findByAbfrage_NameAbfrageIgnoreCase("hallo"))
@@ -170,6 +173,7 @@ class AbfrageServiceTest {
 
         final InfrastrukturabfrageModel expected = new InfrastrukturabfrageModel();
         expected.setId(saveResult.getId());
+        expected.setSub(sub);
         final AbfrageModel expectedAbfrage = new AbfrageModel();
         expectedAbfrage.setStatusAbfrage(abfrage.getStatusAbfrage());
         expectedAbfrage.setNameAbfrage(abfrage.getNameAbfrage());
@@ -185,8 +189,10 @@ class AbfrageServiceTest {
     @Test
     void saveInfrastrukturabfrageWithAngelegtStatus() throws UniqueViolationException, OptimisticLockingException {
         final UUID uuid = UUID.randomUUID();
+        final String sub = "1234";
         final InfrastrukturabfrageModel infrastrukturabfrageModel = new InfrastrukturabfrageModel();
         infrastrukturabfrageModel.setId(null);
+        infrastrukturabfrageModel.setSub(null);
         final AbfrageModel abfrageModel = new AbfrageModel();
         abfrageModel.setNameAbfrage("hallo");
         abfrageModel.setStatusAbfrage(StatusAbfrage.OFFEN);
@@ -195,6 +201,7 @@ class AbfrageServiceTest {
         // Mockito vergleicht die Objekte auf Feldebene weshalb das Objekt genauso sein muss wie wenn es von der Methode aufgerufen wird.
         final Infrastrukturabfrage infrastrukturabfrageEntity = new Infrastrukturabfrage();
         infrastrukturabfrageEntity.setId(null);
+        infrastrukturabfrageEntity.setSub(sub);
         final Abfrage abfrageEntity = new Abfrage();
         abfrageEntity.setNameAbfrage("hallo");
         abfrageEntity.setStatusAbfrage(StatusAbfrage.ANGELEGT);
@@ -202,10 +209,13 @@ class AbfrageServiceTest {
 
         final Infrastrukturabfrage saveResult = new Infrastrukturabfrage();
         saveResult.setId(uuid);
+        saveResult.setSub(sub);
         final Abfrage abfrage = new Abfrage();
         abfrage.setNameAbfrage("hallo");
         abfrage.setStatusAbfrage(StatusAbfrage.ANGELEGT);
         saveResult.setAbfrage(abfrage);
+
+        Mockito.when(this.authenticationUtils.getUserSub()).thenReturn(sub);
 
         Mockito
             .when(this.infrastrukturabfrageRepository.saveAndFlush(infrastrukturabfrageEntity))
@@ -219,6 +229,7 @@ class AbfrageServiceTest {
 
         final InfrastrukturabfrageModel expected = new InfrastrukturabfrageModel();
         expected.setId(saveResult.getId());
+        expected.setSub(saveResult.getSub());
         final AbfrageModel expectedAbfrage = new AbfrageModel();
         expectedAbfrage.setStatusAbfrage(abfrage.getStatusAbfrage());
         expectedAbfrage.setNameAbfrage(abfrage.getNameAbfrage());
@@ -590,9 +601,11 @@ class AbfrageServiceTest {
         final UUID id = UUID.randomUUID();
 
         String[] roles = { "abfrageerstellung" };
+        String sub = "1234";
 
         final Infrastrukturabfrage entity = new Infrastrukturabfrage();
         entity.setId(id);
+        entity.setSub(sub);
         final Abfrage abfrage = new Abfrage();
         abfrage.setStatusAbfrage(StatusAbfrage.ANGELEGT);
         entity.setAbfrage(abfrage);
@@ -600,6 +613,8 @@ class AbfrageServiceTest {
         Mockito.when(this.infrastrukturabfrageRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
 
         Mockito.when(this.authenticationUtils.getUserRoles()).thenReturn(List.of(roles));
+
+        Mockito.when(this.authenticationUtils.getUserSub()).thenReturn(sub);
 
         this.abfrageService.deleteInfrasturkturabfrageById(id);
 
@@ -613,9 +628,11 @@ class AbfrageServiceTest {
         final UUID id = UUID.randomUUID();
 
         String[] roles = { "admin" };
+        String sub = "1234";
 
         final Infrastrukturabfrage entity = new Infrastrukturabfrage();
         entity.setId(id);
+        entity.setSub(sub);
         final Abfrage abfrage = new Abfrage();
         abfrage.setStatusAbfrage(StatusAbfrage.OFFEN);
         entity.setAbfrage(abfrage);
@@ -624,10 +641,37 @@ class AbfrageServiceTest {
 
         Mockito.when(this.authenticationUtils.getUserRoles()).thenReturn(List.of(roles));
 
+        Mockito.when(this.authenticationUtils.getUserSub()).thenReturn(sub);
+
         this.abfrageService.deleteInfrasturkturabfrageById(id);
 
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).findById(entity.getId());
         Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).deleteById(id);
+    }
+
+    @Test
+    void deleteInfrastrukturabfrageUserNotAllowedException() {
+        final UUID id = UUID.randomUUID();
+        String[] roles = { "abfrageerstellung" };
+        String sub = "1234";
+        final Infrastrukturabfrage entity = new Infrastrukturabfrage();
+        entity.setId(id);
+        entity.setSub("123");
+        final Abfrage abfrage = new Abfrage();
+        abfrage.setStatusAbfrage(StatusAbfrage.ANGELEGT);
+        entity.setAbfrage(abfrage);
+
+        Mockito.when(this.infrastrukturabfrageRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
+        Mockito.when(this.authenticationUtils.getUserRoles()).thenReturn(List.of(roles));
+        Mockito.when(this.authenticationUtils.getUserSub()).thenReturn(sub);
+
+        Assertions.assertThrows(
+            UserRoleNotAllowedException.class,
+            () -> this.abfrageService.deleteInfrasturkturabfrageById(id)
+        );
+
+        Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(1)).findById(entity.getId());
+        Mockito.verify(this.infrastrukturabfrageRepository, Mockito.times(0)).deleteById(id);
     }
 
     @Test


### PR DESCRIPTION
**Description**

Implementierung von einer Überprüfung beim Löschen das nur der Ersteller der Abfrage die eigene Abfrage löschen kann. Dies geschieht durch die sub Id vom SSO Endpoint. 

Beim Erstellen der Abfrage wird die sub id in der Datenbank als Attribut von der Abfrage abgespeichert. Beim Löschen wird überprüft ob die sub id vom Nutzer mit der in der Datenbank übereinstimmt.

**Reference**

Issues #827
