### PR TITLE
ISI-517-Bugfix-Fortlaufende-Bauvorhabennummer-4-statt-5-Stellen

### DIFF
--- a/src/main/java/de/muenchen/isi/domain/service/BauvorhabenService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/BauvorhabenService.java
@@ -418,7 +418,7 @@ public class BauvorhabenService {
                     return String.format(
                         "%s_%s",
                         minStadtbezirkNummer.get(),
-                        StringUtils.leftPad(String.valueOf(bauvorhabennummerEntity.getCounter()), 5, "0")
+                        StringUtils.leftPad(String.valueOf(bauvorhabennummerEntity.getCounter()), 4, "0")
                     );
                 } catch (final ObjectOptimisticLockingFailureException exception) {
                     final var message = "Die Daten wurden in der Zwischenzeit geändert. Bitte laden Sie die Seite neu!";

--- a/src/test/java/de/muenchen/isi/domain/service/BauvorhabenServiceTest.java
+++ b/src/test/java/de/muenchen/isi/domain/service/BauvorhabenServiceTest.java
@@ -400,7 +400,7 @@ public class BauvorhabenServiceTest {
             Stream.of(bauvorhabenEntity_sb_20, bauvorhabenEntity_sb_08).collect(Collectors.toSet())
         );
         bauvorhabenEntity.setVerortung(bauvorhabenEntityVerortung);
-        bauvorhabenEntity.setBauvorhabenNummer("08_00001");
+        bauvorhabenEntity.setBauvorhabenNummer("08_0001");
 
         // Saved Bauvorhaben
         final Bauvorhaben saveResult = new Bauvorhaben();
@@ -417,7 +417,7 @@ public class BauvorhabenServiceTest {
         final Verortung saveResultVerortung = new Verortung();
         saveResultVerortung.setStadtbezirke(Stream.of(saveResult_sb_20, saveResult_sb_08).collect(Collectors.toSet()));
         saveResult.setVerortung(saveResultVerortung);
-        saveResult.setBauvorhabenNummer("08_00001");
+        saveResult.setBauvorhabenNummer("08_0001");
 
         Mockito
             .when(this.globalCounterRepository.findByCounterType(CounterType.NUMMER_BAUVORHABEN))
@@ -454,7 +454,7 @@ public class BauvorhabenServiceTest {
         final VerortungModel expectedVerortung = new VerortungModel();
         expectedVerortung.setStadtbezirke(Stream.of(expected_sb_20, expected_sb_08).collect(Collectors.toSet()));
         expected.setVerortung(expectedVerortung);
-        expected.setBauvorhabenNummer("08_00001");
+        expected.setBauvorhabenNummer("08_0001");
 
         assertThat(result, is(expected));
 


### PR DESCRIPTION
**Description**

Bug gemäß Story [ISI-909](https://jira.muenchen.de/browse/ISI-909) gefixt

**Reference**
#ISI-517-Bugfix-Fortlaufende-Bauvorhabennummer-4-statt-5-Stellen

