### PR TITLE
ISI-927-Umlegung-Foerderarten

### DIFF
--- a/src/main/java/de/muenchen/isi/domain/mapper/StammdatenDomainMapper.java
+++ b/src/main/java/de/muenchen/isi/domain/mapper/StammdatenDomainMapper.java
@@ -4,11 +4,13 @@ import de.muenchen.isi.configuration.MapstructConfiguration;
 import de.muenchen.isi.domain.model.stammdaten.FoerdermixStammModel;
 import de.muenchen.isi.domain.model.stammdaten.SobonOrientierungswertSozialeInfrastrukturModel;
 import de.muenchen.isi.domain.model.stammdaten.StaedtebaulicheOrientierungswertModel;
+import de.muenchen.isi.domain.model.stammdaten.UmlegungFoerderartenModel;
 import de.muenchen.isi.infrastructure.csv.SobonOrientierungswertSozialeInfrastrukturCsv;
 import de.muenchen.isi.infrastructure.csv.StaedtebaulicheOrientierungswertCsv;
 import de.muenchen.isi.infrastructure.entity.stammdaten.FoerdermixStamm;
 import de.muenchen.isi.infrastructure.entity.stammdaten.SobonOrientierungswertSozialeInfrastruktur;
 import de.muenchen.isi.infrastructure.entity.stammdaten.StaedtebaulicheOrientierungswert;
+import de.muenchen.isi.infrastructure.entity.stammdaten.UmlegungFoerderarten;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
@@ -50,4 +52,8 @@ public interface StammdatenDomainMapper {
     FoerdermixStammModel entity2Model(final FoerdermixStamm entity);
 
     FoerdermixStamm model2Entity(final FoerdermixStammModel model);
+
+    UmlegungFoerderartenModel entity2Model(final UmlegungFoerderarten entity);
+
+    UmlegungFoerderarten model2Entity(final UmlegungFoerderartenModel model);
 }

--- a/src/main/java/de/muenchen/isi/domain/model/stammdaten/UmlegungFoerderartenModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/stammdaten/UmlegungFoerderartenModel.java
@@ -1,0 +1,17 @@
+package de.muenchen.isi.domain.model.stammdaten;
+
+import de.muenchen.isi.domain.model.BaseEntityModel;
+import de.muenchen.isi.infrastructure.entity.Foerderart;
+import java.time.LocalDate;
+import java.util.Set;
+import lombok.Data;
+
+@Data
+public class UmlegungFoerderartenModel extends BaseEntityModel {
+
+    private String bezeichnung;
+
+    private LocalDate gueltigAb;
+
+    private Set<Foerderart> umlegungsschluessel;
+}

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/Foerderart.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/Foerderart.java
@@ -11,6 +11,6 @@ public class Foerderart {
 
     private String bezeichnung;
 
-    @Column(precision = 4, scale = 2)
+    @Column(precision = 5, scale = 2)
     private BigDecimal anteilProzent;
 }

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/Foerderart.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/Foerderart.java
@@ -1,6 +1,7 @@
 package de.muenchen.isi.infrastructure.entity;
 
 import java.math.BigDecimal;
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.Data;
 
@@ -10,5 +11,6 @@ public class Foerderart {
 
     private String bezeichnung;
 
+    @Column(precision = 4, scale = 2)
     private BigDecimal anteilProzent;
 }

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/stammdaten/UmlegungFoerderarten.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/stammdaten/UmlegungFoerderarten.java
@@ -1,0 +1,35 @@
+package de.muenchen.isi.infrastructure.entity.stammdaten;
+
+import de.muenchen.isi.infrastructure.entity.BaseEntity;
+import de.muenchen.isi.infrastructure.entity.Foerderart;
+import java.time.LocalDate;
+import java.util.Set;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.Type;
+
+@Entity
+@Table(
+    uniqueConstraints = {
+        @UniqueConstraint(name = "UniqueUmlegungFoerderarten", columnNames = { "bezeichnung", "gueltigAb" }),
+    }
+)
+@Data
+@EqualsAndHashCode
+public class UmlegungFoerderarten extends BaseEntity {
+
+    @Column(nullable = false)
+    private String bezeichnung;
+
+    @Column(nullable = false)
+    private LocalDate gueltigAb;
+
+    // Die Klasse Foerderart existiert bereits.
+    @Type(type = "json")
+    @Column(columnDefinition = "jsonb")
+    private Set<Foerderart> umlegungsschluessel;
+}

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/stammdaten/UmlegungFoerderarten.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/stammdaten/UmlegungFoerderarten.java
@@ -28,7 +28,6 @@ public class UmlegungFoerderarten extends BaseEntity {
     @Column(nullable = false)
     private LocalDate gueltigAb;
 
-    // Die Klasse Foerderart existiert bereits.
     @Type(type = "json")
     @Column(columnDefinition = "jsonb")
     private Set<Foerderart> umlegungsschluessel;

--- a/src/main/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepository.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepository.java
@@ -1,10 +1,14 @@
 package de.muenchen.isi.infrastructure.repository.stammdaten;
 
 import de.muenchen.isi.infrastructure.entity.stammdaten.UmlegungFoerderarten;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UmlegungFoerderartenRepository extends JpaRepository<UmlegungFoerderarten, UUID> {
-    Optional<UmlegungFoerderarten> findBybezeichnung(final String bezeichnung);
+    Optional<UmlegungFoerderarten> findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+        final String bezeichnung,
+        final LocalDate datum
+    );
 }

--- a/src/main/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepository.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepository.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UmlegungFoerderartenRepository extends JpaRepository<UmlegungFoerderarten, UUID> {
-    Optional<UmlegungFoerderarten> findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+    Optional<UmlegungFoerderarten> findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
         final String bezeichnung,
         final LocalDate datum
     );

--- a/src/main/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepository.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepository.java
@@ -1,0 +1,10 @@
+package de.muenchen.isi.infrastructure.repository.stammdaten;
+
+import de.muenchen.isi.infrastructure.entity.stammdaten.UmlegungFoerderarten;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UmlegungFoerderartenRepository extends JpaRepository<UmlegungFoerderarten, UUID> {
+    Optional<UmlegungFoerderarten> findBybezeichnung(final String bezeichnung);
+}

--- a/src/main/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepository.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepository.java
@@ -5,15 +5,18 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface UmlegungFoerderartenRepository extends JpaRepository<UmlegungFoerderarten, UUID> {
-    @Query(
-        "SELECT umlegung FROM UmlegungFoerderarten umlegung WHERE umlegung.bezeichnung = :bezeichnung AND umlegung.gueltigAb <= :datum ORDER BY umlegung.gueltigAb DESC"
-    )
-    Optional<UmlegungFoerderarten> findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
-        @Param("bezeichnung") final String bezeichnung,
-        @Param("datum") final LocalDate datum
+    /**
+     * Findet den ersten Eintrag mit einer bestimmten Bezeichnung, bei dem das Gültigkeitsdatum vor oder am
+     * angegebenen Datum liegt, und sortiert die Ergebnisse nach dem Gültigkeitsdatum absteigend.
+     *
+     * @param bezeichnung Die Bezeichnung, nach der gesucht werden soll.
+     * @param datum       Das Datum, bis zu dem das Gültigkeitsdatum liegen soll (einschließlich).
+     * @return Ein {@link Optional} mit dem gefundenen Eintrag, oder ein leeres {@link Optional}, falls kein Eintrag gefunden wurde.
+     */
+    Optional<UmlegungFoerderarten> findFirstByBezeichnungAndGueltigAbIsLessThanEqualOrderByGueltigAbDesc(
+        final String bezeichnung,
+        final LocalDate datum
     );
 }

--- a/src/main/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepository.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepository.java
@@ -5,10 +5,15 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UmlegungFoerderartenRepository extends JpaRepository<UmlegungFoerderarten, UUID> {
-    Optional<UmlegungFoerderarten> findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
-        final String bezeichnung,
-        final LocalDate datum
+    @Query(
+        "SELECT umlegung FROM UmlegungFoerderarten umlegung WHERE umlegung.bezeichnung = :bezeichnung AND umlegung.gueltigAb <= :datum ORDER BY umlegung.gueltigAb DESC"
+    )
+    Optional<UmlegungFoerderarten> findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+        @Param("bezeichnung") final String bezeichnung,
+        @Param("datum") final LocalDate datum
     );
 }

--- a/src/test/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepositoryTest.java
+++ b/src/test/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepositoryTest.java
@@ -58,37 +58,37 @@ public class UmlegungFoerderartenRepositoryTest {
             );
 
         Optional<UmlegungFoerderarten> result1 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbIsLessThanEqualOrderByGueltigAbDesc(
                     umlegungFoerderarten1.getBezeichnung(),
                     LocalDate.parse("2003-05-05")
                 );
 
         Optional<UmlegungFoerderarten> result2 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbIsLessThanEqualOrderByGueltigAbDesc(
                     umlegungFoerderarten2.getBezeichnung(),
                     LocalDate.parse("2005-05-05")
                 );
 
         Optional<UmlegungFoerderarten> result3 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbIsLessThanEqualOrderByGueltigAbDesc(
                     umlegungFoerderarten2.getBezeichnung(),
                     LocalDate.parse("2007-10-15")
                 );
 
         Optional<UmlegungFoerderarten> result4 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbIsLessThanEqualOrderByGueltigAbDesc(
                     umlegungFoerderarten3.getBezeichnung(),
                     LocalDate.parse("2011-06-14")
                 );
 
         Optional<UmlegungFoerderarten> result5 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbIsLessThanEqualOrderByGueltigAbDesc(
                     umlegungFoerderarten1.getBezeichnung(),
                     LocalDate.parse("2005-05-04")
                 );
 
         Optional<UmlegungFoerderarten> result6 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbIsLessThanEqualOrderByGueltigAbDesc(
                     umlegungFoerderarten2.getBezeichnung(),
                     LocalDate.parse("2005-05-06")
                 );
@@ -123,25 +123,25 @@ public class UmlegungFoerderartenRepositoryTest {
             );
 
         Optional<UmlegungFoerderarten> result1 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbIsLessThanEqualOrderByGueltigAbDesc(
                     umlegungFoerderarten1.getBezeichnung(),
                     LocalDate.parse("1999-06-14")
                 );
 
         Optional<UmlegungFoerderarten> result2 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbIsLessThanEqualOrderByGueltigAbDesc(
                     "Test4",
                     LocalDate.parse("2003-05-05")
                 );
 
         Optional<UmlegungFoerderarten> result3 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbIsLessThanEqualOrderByGueltigAbDesc(
                     "Test5",
                     LocalDate.parse("1980-05-05")
                 );
 
         Optional<UmlegungFoerderarten> result4 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbIsLessThanEqualOrderByGueltigAbDesc(
                     umlegungFoerderarten2.getBezeichnung(),
                     LocalDate.parse("2005-05-04")
                 );

--- a/src/test/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepositoryTest.java
+++ b/src/test/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepositoryTest.java
@@ -58,46 +58,97 @@ public class UmlegungFoerderartenRepositoryTest {
             );
 
         Optional<UmlegungFoerderarten> result1 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
                     umlegungFoerderarten1.getBezeichnung(),
                     LocalDate.parse("2003-05-05")
                 );
 
         Optional<UmlegungFoerderarten> result2 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+                    umlegungFoerderarten2.getBezeichnung(),
+                    LocalDate.parse("2005-05-05")
+                );
+
+        Optional<UmlegungFoerderarten> result3 =
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
                     umlegungFoerderarten2.getBezeichnung(),
                     LocalDate.parse("2007-10-15")
                 );
 
-        Optional<UmlegungFoerderarten> result3 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+        Optional<UmlegungFoerderarten> result4 =
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
                     umlegungFoerderarten3.getBezeichnung(),
                     LocalDate.parse("2011-06-14")
                 );
 
-        Optional<UmlegungFoerderarten> result4 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
-                    umlegungFoerderarten1.getBezeichnung(),
-                    LocalDate.parse("1999-06-14")
-                );
-
         Optional<UmlegungFoerderarten> result5 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
-                    "Test4",
-                    LocalDate.parse("2003-05-05")
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+                    umlegungFoerderarten1.getBezeichnung(),
+                    LocalDate.parse("2005-05-04")
                 );
 
         Optional<UmlegungFoerderarten> result6 =
-            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
-                    "Test5",
-                    LocalDate.parse("1980-05-05")
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+                    umlegungFoerderarten2.getBezeichnung(),
+                    LocalDate.parse("2005-05-06")
                 );
 
         assertThat(result1.get(), is(umlegungFoerderarten1));
         assertThat(result2.get(), is(umlegungFoerderarten2));
-        assertThat(result3.get(), is(umlegungFoerderarten3));
+        assertThat(result3.get(), is(umlegungFoerderarten2));
+        assertThat(result4.get(), is(umlegungFoerderarten3));
+        assertThat(result5.get(), is(umlegungFoerderarten1));
+        assertThat(result6.get(), is(umlegungFoerderarten2));
+    }
+
+    @Test
+    void NoSuchElementExceptionUmlegungFoerderartenbyBezeichnungAndDatum() {
+        UmlegungFoerderarten umlegungFoerderarten1 = new UmlegungFoerderarten();
+        umlegungFoerderarten1.setId(UUID.randomUUID());
+        umlegungFoerderarten1.setBezeichnung("Test1");
+        umlegungFoerderarten1.setGueltigAb(LocalDate.parse("2000-01-01"));
+
+        UmlegungFoerderarten umlegungFoerderarten2 = new UmlegungFoerderarten();
+        umlegungFoerderarten2.setId(UUID.randomUUID());
+        umlegungFoerderarten2.setBezeichnung("Test2");
+        umlegungFoerderarten2.setGueltigAb(LocalDate.parse("2005-05-05"));
+
+        UmlegungFoerderarten umlegungFoerderarten3 = new UmlegungFoerderarten();
+        umlegungFoerderarten3.setId(UUID.randomUUID());
+        umlegungFoerderarten3.setBezeichnung("Test3");
+        umlegungFoerderarten3.setGueltigAb(LocalDate.parse("2010-01-01"));
+
+        this.umlegungFoerderartenRepository.saveAll(
+                List.of(umlegungFoerderarten1, umlegungFoerderarten2, umlegungFoerderarten3)
+            );
+
+        Optional<UmlegungFoerderarten> result1 =
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+                    umlegungFoerderarten1.getBezeichnung(),
+                    LocalDate.parse("1999-06-14")
+                );
+
+        Optional<UmlegungFoerderarten> result2 =
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+                    "Test4",
+                    LocalDate.parse("2003-05-05")
+                );
+
+        Optional<UmlegungFoerderarten> result3 =
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+                    "Test5",
+                    LocalDate.parse("1980-05-05")
+                );
+
+        Optional<UmlegungFoerderarten> result4 =
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrEqualToOrderByGueltigAbDesc(
+                    umlegungFoerderarten2.getBezeichnung(),
+                    LocalDate.parse("2005-05-04")
+                );
+
+        Assertions.assertThrows(NoSuchElementException.class, () -> result1.get());
+        Assertions.assertThrows(NoSuchElementException.class, () -> result2.get());
+        Assertions.assertThrows(NoSuchElementException.class, () -> result3.get());
         Assertions.assertThrows(NoSuchElementException.class, () -> result4.get());
-        Assertions.assertThrows(NoSuchElementException.class, () -> result5.get());
-        Assertions.assertThrows(NoSuchElementException.class, () -> result6.get());
     }
 }

--- a/src/test/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepositoryTest.java
+++ b/src/test/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepositoryTest.java
@@ -58,37 +58,37 @@ public class UmlegungFoerderartenRepositoryTest {
             );
 
         Optional<UmlegungFoerderarten> result1 =
-            this.umlegungFoerderartenRepository.findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
                     umlegungFoerderarten1.getBezeichnung(),
                     LocalDate.parse("2003-05-05")
                 );
 
         Optional<UmlegungFoerderarten> result2 =
-            this.umlegungFoerderartenRepository.findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
                     umlegungFoerderarten2.getBezeichnung(),
                     LocalDate.parse("2007-10-15")
                 );
 
         Optional<UmlegungFoerderarten> result3 =
-            this.umlegungFoerderartenRepository.findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
                     umlegungFoerderarten3.getBezeichnung(),
                     LocalDate.parse("2011-06-14")
                 );
 
         Optional<UmlegungFoerderarten> result4 =
-            this.umlegungFoerderartenRepository.findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
                     umlegungFoerderarten1.getBezeichnung(),
                     LocalDate.parse("1999-06-14")
                 );
 
         Optional<UmlegungFoerderarten> result5 =
-            this.umlegungFoerderartenRepository.findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
                     "Test4",
                     LocalDate.parse("2003-05-05")
                 );
 
         Optional<UmlegungFoerderarten> result6 =
-            this.umlegungFoerderartenRepository.findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+            this.umlegungFoerderartenRepository.findFirstByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
                     "Test5",
                     LocalDate.parse("1980-05-05")
                 );

--- a/src/test/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepositoryTest.java
+++ b/src/test/java/de/muenchen/isi/infrastructure/repository/stammdaten/UmlegungFoerderartenRepositoryTest.java
@@ -1,0 +1,103 @@
+package de.muenchen.isi.infrastructure.repository.stammdaten;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import de.muenchen.isi.IsiBackendApplication;
+import de.muenchen.isi.TestConstants;
+import de.muenchen.isi.infrastructure.entity.stammdaten.UmlegungFoerderarten;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest(classes = { IsiBackendApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles(profiles = { TestConstants.SPRING_UNIT_TEST_PROFILE, TestConstants.SPRING_NO_SECURITY_PROFILE })
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class UmlegungFoerderartenRepositoryTest {
+
+    @Autowired
+    private UmlegungFoerderartenRepository umlegungFoerderartenRepository;
+
+    @BeforeEach
+    public void beforeEach() {
+        this.umlegungFoerderartenRepository.deleteAll();
+    }
+
+    @Test
+    void findUmlegungFoerderartenbyBezeichnungAndDatum() {
+        UmlegungFoerderarten umlegungFoerderarten1 = new UmlegungFoerderarten();
+        umlegungFoerderarten1.setId(UUID.randomUUID());
+        umlegungFoerderarten1.setBezeichnung("Test1");
+        umlegungFoerderarten1.setGueltigAb(LocalDate.parse("2000-01-01"));
+
+        UmlegungFoerderarten umlegungFoerderarten2 = new UmlegungFoerderarten();
+        umlegungFoerderarten2.setId(UUID.randomUUID());
+        umlegungFoerderarten2.setBezeichnung("Test2");
+        umlegungFoerderarten2.setGueltigAb(LocalDate.parse("2005-05-05"));
+
+        UmlegungFoerderarten umlegungFoerderarten3 = new UmlegungFoerderarten();
+        umlegungFoerderarten3.setId(UUID.randomUUID());
+        umlegungFoerderarten3.setBezeichnung("Test3");
+        umlegungFoerderarten3.setGueltigAb(LocalDate.parse("2010-01-01"));
+
+        this.umlegungFoerderartenRepository.saveAll(
+                List.of(umlegungFoerderarten1, umlegungFoerderarten2, umlegungFoerderarten3)
+            );
+
+        Optional<UmlegungFoerderarten> result1 =
+            this.umlegungFoerderartenRepository.findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+                    umlegungFoerderarten1.getBezeichnung(),
+                    LocalDate.parse("2003-05-05")
+                );
+
+        Optional<UmlegungFoerderarten> result2 =
+            this.umlegungFoerderartenRepository.findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+                    umlegungFoerderarten2.getBezeichnung(),
+                    LocalDate.parse("2007-10-15")
+                );
+
+        Optional<UmlegungFoerderarten> result3 =
+            this.umlegungFoerderartenRepository.findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+                    umlegungFoerderarten3.getBezeichnung(),
+                    LocalDate.parse("2011-06-14")
+                );
+
+        Optional<UmlegungFoerderarten> result4 =
+            this.umlegungFoerderartenRepository.findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+                    umlegungFoerderarten1.getBezeichnung(),
+                    LocalDate.parse("1999-06-14")
+                );
+
+        Optional<UmlegungFoerderarten> result5 =
+            this.umlegungFoerderartenRepository.findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+                    "Test4",
+                    LocalDate.parse("2003-05-05")
+                );
+
+        Optional<UmlegungFoerderarten> result6 =
+            this.umlegungFoerderartenRepository.findByBezeichnungAndGueltigAbBeforeOrderByGueltigAbDesc(
+                    "Test5",
+                    LocalDate.parse("1980-05-05")
+                );
+
+        assertThat(result1.get(), is(umlegungFoerderarten1));
+        assertThat(result2.get(), is(umlegungFoerderarten2));
+        assertThat(result3.get(), is(umlegungFoerderarten3));
+        Assertions.assertThrows(NoSuchElementException.class, () -> result4.get());
+        Assertions.assertThrows(NoSuchElementException.class, () -> result5.get());
+        Assertions.assertThrows(NoSuchElementException.class, () -> result6.get());
+    }
+}


### PR DESCRIPTION
**Description**

Umlegungs Klasse erstellt welche die Förderarten die Umgelegt werden müssen speichert.

Da es nur für die Berechnung nötig ist gibt es keine DTO Klasse

Diese MR wurde neu erstelllt da ich denn ISI-906 Branch noch in meinen drinnen hatte und nun alles resetet habe.

**Reference**

Issues #XXX
