### PR TITLE
ISI-1234 Hebung Spring-Boot 3.2.1 mit Hibernate-Search 7.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>3.2.0</spring.boot.version>
+        <spring.boot.version>3.2.1</spring.boot.version>
         <spring.cloud.version>2023.0.0</spring.cloud.version>
         <logstash.encoder>7.0.1</logstash.encoder>
         <apache.commons.collections4>4.4</apache.commons.collections4>
@@ -47,7 +47,7 @@
         <geotools.version>29.1</geotools.version>
         <spring.statemachine>4.0.0</spring.statemachine>
         <apache.tika.version>2.9.1</apache.tika.version>
-        <hibernate.search>6.2.2.Final</hibernate.search>
+        <hibernate.search>7.0.0.Final</hibernate.search>
         <icu4j.version>74.2</icu4j.version>
     </properties>
 
@@ -209,7 +209,7 @@
         <!-- Search -->
         <dependency>
             <groupId>org.hibernate.search</groupId>
-            <artifactId>hibernate-search-mapper-orm-orm6</artifactId>
+            <artifactId>hibernate-search-mapper-orm</artifactId>
             <version>${hibernate.search}</version>
         </dependency>
         <dependency>

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/infrastruktureinrichtung/Infrastruktureinrichtung.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/infrastruktureinrichtung/Infrastruktureinrichtung.java
@@ -32,8 +32,8 @@ import lombok.ToString;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.hibernate.annotations.Generated;
-import org.hibernate.annotations.GenerationTime;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.generator.EventType;
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBinderRef;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
@@ -65,7 +65,7 @@ public abstract class Infrastruktureinrichtung extends BaseEntity {
             : EnumUtils.getEnum(InfrastruktureinrichtungTyp.class, discriminatorValue.value());
     }
 
-    @Generated(GenerationTime.INSERT)
+    @Generated(event = EventType.INSERT)
     @Column(name = "lfdNr", columnDefinition = "serial", updatable = false)
     private Long lfdNr;
 

--- a/src/test/java/de/muenchen/isi/api/advice/RestExceptionHandlerTest.java
+++ b/src/test/java/de/muenchen/isi/api/advice/RestExceptionHandlerTest.java
@@ -141,7 +141,7 @@ class RestExceptionHandlerTest {
         final ResponseEntity<Object> response =
             this.restExceptionHandler.handleFileImportFailedException(fileImportFailedException);
 
-        assertThat(response.getStatusCodeValue(), is(555));
+        assertThat(response.getStatusCode().value(), is(555));
 
         final InformationResponseDto responseDto = (InformationResponseDto) response.getBody();
 
@@ -158,7 +158,7 @@ class RestExceptionHandlerTest {
         final ResponseEntity<Object> response =
             this.restExceptionHandler.handleMimeTypeNotAllowedException(mimeTypeNotAllowedException);
 
-        assertThat(response.getStatusCodeValue(), is(406));
+        assertThat(response.getStatusCode().value(), is(406));
 
         final InformationResponseDto responseDto = (InformationResponseDto) response.getBody();
 
@@ -176,7 +176,7 @@ class RestExceptionHandlerTest {
         final ResponseEntity<Object> response =
             this.restExceptionHandler.handleMimeTypeExtractionFailedException(mimeTypeExtractionFailedException);
 
-        assertThat(response.getStatusCodeValue(), is(555));
+        assertThat(response.getStatusCode().value(), is(555));
 
         final InformationResponseDto responseDto = (InformationResponseDto) response.getBody();
 
@@ -193,7 +193,7 @@ class RestExceptionHandlerTest {
         final ResponseEntity<Object> response =
             this.restExceptionHandler.handleFileHandlingFailedException(fileImportFailedException);
 
-        assertThat(response.getStatusCodeValue(), is(555));
+        assertThat(response.getStatusCode().value(), is(555));
 
         final InformationResponseDto responseDto = (InformationResponseDto) response.getBody();
 
@@ -236,7 +236,7 @@ class RestExceptionHandlerTest {
         fileHandlingWithS3FailedException = new FileHandlingWithS3FailedException("test", HttpStatus.NOT_ACCEPTABLE);
         response = this.restExceptionHandler.handleFileHandlingWithS3FailedException(fileHandlingWithS3FailedException);
 
-        assertThat(response.getStatusCodeValue(), is(555));
+        assertThat(response.getStatusCode().value(), is(555));
 
         responseDto = (InformationResponseDto) response.getBody();
 
@@ -253,7 +253,7 @@ class RestExceptionHandlerTest {
         final ResponseEntity<Object> response =
             this.restExceptionHandler.handleKoordinatenException(koordinatenException);
 
-        assertThat(response.getStatusCodeValue(), is(555));
+        assertThat(response.getStatusCode().value(), is(555));
 
         final InformationResponseDto responseDto = (InformationResponseDto) response.getBody();
 


### PR DESCRIPTION
**Description**

* Hebung von Spring-Boot 3.2.0 (Hibernate-Core 6.3) auf 3.2.1 (Hibernate-Code 6.4)
* Hebung von Hibernate-Search von 6.2.2 auf 7.0.0 um Kompatibilität mit Hibernate-Core 6.4 zu gewährleisten.
* Anpassen API welche Deprecated ist

**Reference**

Issues ISI-1234
