### PR TITLE
Isi 1756 foerdermix so bon ursaechlichkeit umbenennen

### DIFF
--- a/src/main/java/de/muenchen/isi/domain/service/etlInterface/EtlInterfaceService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/etlInterface/EtlInterfaceService.java
@@ -95,7 +95,10 @@ public class EtlInterfaceService {
             try {
                 etlInterfaceRepository.etlTriggerJob(etlTriggerJobDto);
             } catch (final Exception exception) {
-                final var error = "Beim Aufruf des ETL-Systems (Pentaho) ist ein Fehler aufgetreten.";
+                final var error =
+                    "Beim Aufruf des ETL-Systems (Pentaho), Job: " +
+                    etlTriggerJobDto.getJobname() +
+                    ", ist ein Fehler aufgetreten";
                 log.error(error, exception);
                 throw new ReportingException(error, exception);
             }

--- a/src/main/resources/db/migration/V26__ISI-1756_Umbenennung_Foerdermix.sql
+++ b/src/main/resources/db/migration/V26__ISI-1756_Umbenennung_Foerdermix.sql
@@ -1,0 +1,10 @@
+--
+-- Umbenennung Fördermix "SoBoN-Ursächlichkeit" in "SoBoN 2017"
+--
+BEGIN;
+
+UPDATE baurate
+SET bezeichnung = 'SoBoN 2017'
+WHERE bezeichnung = 'SoBoN-Ursächlichkeit';
+
+END;


### PR DESCRIPTION
**Description**

Umsetzung der Story [ISI-1756](https://jira.muenchen.de/browse/ISI-1756)

- Umbenennung Fördermix "SoBoN-Ursächlichkeit" in "SoBoN 2017"

- Bei Pentaho Fehler wird Jobname ausgegeben

Issues #ISI-1756
