### PR TITLE
ISI-1779-API-Gateway-nicht-verfuegbar

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,15 @@ spring:
     uris: ${spring.jpa.properties.hibernate.search.backend.hosts}
     username: ${spring.jpa.properties.hibernate.search.backend.username}
     password: ${spring.jpa.properties.hibernate.search.backend.password}
-    connection-timeout: ${spring.jpa.properties.hibernate.search.backend.connection-timeout}
-    socket-timeout: ${spring.jpa.properties.hibernate.search.backend.socket-timeout}
+    connection-timeout: ${spring.jpa.properties.elasticsearch.connection-timeout}
+    socket-timeout: ${spring.jpa.properties.elasticsearch.socket-timeout}
+
+hibernate:
+  search:
+    backend:
+      request_timeout: ${spring.jpa.properties.hibernate.search.backend.request_timeout}
+      connection_timeout : ${spring.jpa.properties.hibernate.search.backend.connection_timeout}
+      read_timeout: ${spring.jpa.properties.hibernate.search.backend.read_timeout}
 
 server:
   shutdown: "graceful"

--- a/src/test/resources/application-unittest.yml
+++ b/src/test/resources/application-unittest.yml
@@ -38,8 +38,11 @@ spring:
             hosts: localhost:9200
             username: elastic
             password: changeme
-            connection-timeout: 10
-            socket-timeout: 30
+            connection_timeout: 1000
+            read_timeout: 60000
+      elasticsearch:
+        connection-timeout: 10s
+        socket-timeout: 60s
 
   mail:
     host: dummy.smtp.unittest.com


### PR DESCRIPTION
**Description**

Hibernate & Elasticsearch Timeout Parameter

**Reference**

Issues #ISI-1779
