### PR TITLE
Fix elasticsearch

### DIFF
--- a/src/main/java/de/muenchen/isi/configuration/search/ElasticsearchKeepAliveConfig.java
+++ b/src/main/java/de/muenchen/isi/configuration/search/ElasticsearchKeepAliveConfig.java
@@ -1,0 +1,40 @@
+package de.muenchen.isi.configuration.search;
+
+import org.apache.http.HeaderElement;
+import org.apache.http.HeaderElementIterator;
+import org.apache.http.message.BasicHeaderElementIterator;
+import org.apache.http.protocol.HTTP;
+import org.hibernate.search.backend.elasticsearch.client.ElasticsearchHttpClientConfigurationContext;
+import org.hibernate.search.backend.elasticsearch.client.ElasticsearchHttpClientConfigurer;
+
+public class ElasticsearchKeepAliveConfig implements ElasticsearchHttpClientConfigurer {
+
+    public static final int MILLISECOND = 1;
+    public static final int SECOND = 1000 * MILLISECOND;
+
+    @Override
+    public void configure(ElasticsearchHttpClientConfigurationContext context) {
+        var clientBuilder = context.clientBuilder();
+        clientBuilder.setKeepAliveStrategy((httpResponse, httpContext) -> {
+            HeaderElementIterator it = new BasicHeaderElementIterator(
+                httpResponse.headerIterator(HTTP.CONN_KEEP_ALIVE)
+            );
+
+            while (it.hasNext()) {
+                HeaderElement he = it.nextElement();
+                String param = he.getName();
+                String value = he.getValue();
+                if (value != null && param.equalsIgnoreCase("timeout")) {
+                    try {
+                        var timeoutSeconds = Long.parseLong(value);
+                        return timeoutSeconds * SECOND;
+                    } catch (NumberFormatException ignore) {}
+                }
+            }
+
+            // Connections nicht undendlich lange offen halten,
+            // da Netzwerk-Firewall sie sonst evtl. mit deny auslaufen lässt.
+            return 30 * SECOND;
+        });
+    }
+}

--- a/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
@@ -32,6 +32,7 @@ import org.hibernate.search.engine.search.predicate.dsl.SimpleBooleanPredicateCl
 import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
 import org.hibernate.search.mapper.orm.Search;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -46,6 +47,9 @@ public class EntitySearchService {
 
     @PersistenceContext
     private EntityManager entityManager;
+
+    @Value("${spring.jpa.properties.hibernate.search.backend.read_timeout}")
+    private Long durationFetch;
 
     /**
      * Diese Methode führt die paginierte Entitätssuche für die im Methodenparameter gegebenen Informationen durch.
@@ -495,7 +499,7 @@ public class EntitySearchService {
 
         // **Setze ein Timeout von 10 Sekunden**
         final SearchResult<BaseEntity> searchResult = searchQueryOptions
-            .failAfter(Duration.ofSeconds(30).toSeconds(), TimeUnit.SECONDS) // Timeout setzen
+            .failAfter(Duration.ofMillis(durationFetch).toMillis(), TimeUnit.MILLISECONDS) // Timeout setzen
             .fetch(paginationOffset != null ? paginationOffset : 0, pageSize);
 
         final var searchResults = searchResult
@@ -507,7 +511,7 @@ public class EntitySearchService {
         final var model = new SearchResultsModel();
         model.setSearchResults(searchResults);
 
-        if (paginationOffset != null) {
+        if (ObjectUtils.isNotEmpty(paginationOffset)) {
             final long numberOfTotalHits = searchResult.total().hitCount();
             final var numberOfPages = calculateNumberOfPages(numberOfTotalHits, pageSize);
             model.setNumberOfPages(numberOfPages);

--- a/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
@@ -532,7 +532,7 @@ public class EntitySearchService {
                 paginationOffset,
                 searchQueryAndSortingInformation.getPageSize()
             );
-            throw new SearchTimeoutException(exception.getMessage());
+            throw exception;
         }
     }
 

--- a/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
@@ -49,10 +49,10 @@ public class EntitySearchService {
     private EntityManager entityManager;
 
     @Value("${search.durationFetch}")
-    private Long durationFetch = 30000L;
+    final Long durationFetch = 60000L;
 
     @Value("${search.totalHitCountThreshold}")
-    private int totalHitCountThreshold = 1000;
+    final int totalHitCountThreshold = 1000;
 
     private static final int maximumPageSize = 500;
 

--- a/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
@@ -48,8 +48,13 @@ public class EntitySearchService {
     @PersistenceContext
     private EntityManager entityManager;
 
-    @Value("${spring.jpa.properties.hibernate.search.backend.read_timeout}")
-    private Long durationFetch;
+    @Value("${search.durationFetch}")
+    private Long durationFetch = 30000L;
+
+    @Value("${search.totalHitCountThreshold}")
+    private int totalHitCountThreshold = 1000;
+
+    private static final int maximumPageSize = 500;
 
     /**
      * Diese Methode führt die paginierte Entitätssuche für die im Methodenparameter gegebenen Informationen durch.
@@ -109,8 +114,8 @@ public class EntitySearchService {
                         function
                     );
             })
-            // Setze eine Begrenzung für `trackTotalHits`, um Performance zu verbessern
-            .totalHitCountThreshold(1000) // Zählt max. 1000 Treffer, vermeidet lange Berechnungen
+            // Setze eine Begrenzung für `trackTotalHits` mit totalHitCountThreshhold, um Performance zu verbessern
+            .totalHitCountThreshold(totalHitCountThreshold)
             // Sortierung der Suchergebnisse.
             // https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#query-sorting
             .sort(function -> {
@@ -492,12 +497,12 @@ public class EntitySearchService {
     ) {
         final Integer paginationOffset = calculateOffsetOrNullIfNoPaginationRequired(searchQueryAndSortingInformation);
 
-        // **Maximale Größe auf 500 setzen, falls keine Paginierung definiert ist**
+        // Maximale Größe auf maximumPageSize setzen, falls keine Paginierung definiert ist
         final int pageSize = ObjectUtils.isNotEmpty(paginationOffset)
             ? searchQueryAndSortingInformation.getPageSize()
-            : Math.min(500, searchQueryAndSortingInformation.getPageSize());
+            : Math.min(maximumPageSize, searchQueryAndSortingInformation.getPageSize());
 
-        // **Setze ein Timeout von 10 Sekunden**
+        // Setzt ein Timeout von durationFetch
         final SearchResult<BaseEntity> searchResult = searchQueryOptions
             .failAfter(Duration.ofMillis(durationFetch).toMillis(), TimeUnit.MILLISECONDS) // Timeout setzen
             .fetch(paginationOffset != null ? paginationOffset : 0, pageSize);

--- a/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
@@ -496,16 +496,23 @@ public class EntitySearchService {
         final SearchQueryOptionsStep searchQueryOptions
     ) {
         final Integer paginationOffset = calculateOffsetOrNullIfNoPaginationRequired(searchQueryAndSortingInformation);
+        final Integer providedPageSize = searchQueryAndSortingInformation.getPageSize();
+        final SearchResult<BaseEntity> searchResult;
 
-        // Maximale Größe auf maximumPageSize setzen, falls keine Paginierung definiert ist
-        final int pageSize = ObjectUtils.isNotEmpty(paginationOffset)
-            ? searchQueryAndSortingInformation.getPageSize()
-            : Math.min(maximumPageSize, searchQueryAndSortingInformation.getPageSize());
-        log.debug(String.format("EntitySearchService.executeSearchQuery(), pageSize: %d", pageSize));
-        // Setzt ein Timeout von durationFetch
-        final SearchResult<BaseEntity> searchResult = searchQueryOptions
-            .failAfter(Duration.ofMillis(durationFetch).toMillis(), TimeUnit.MILLISECONDS) // Timeout setzen
-            .fetch(paginationOffset != null ? paginationOffset : 0, pageSize);
+        if (providedPageSize == null) {
+            log.debug("No pageSize provided, executing non-paginated search with fetchAll()");
+            searchResult = searchQueryOptions
+                .failAfter(Duration.ofMillis(durationFetch).toMillis(), TimeUnit.MILLISECONDS)
+                .fetchAll();
+        } else {
+            final int pageSize = (paginationOffset != null)
+                ? providedPageSize
+                : Math.min(maximumPageSize, providedPageSize);
+            log.debug("EntitySearchService.executeSearchQuery(), pageSize: {}", pageSize);
+            searchResult = searchQueryOptions
+                .failAfter(Duration.ofMillis(durationFetch).toMillis(), TimeUnit.MILLISECONDS)
+                .fetch(paginationOffset != null ? paginationOffset : 0, pageSize);
+        }
 
         final var searchResults = searchResult
             .hits()
@@ -516,27 +523,15 @@ public class EntitySearchService {
         final var model = new SearchResultsModel();
         model.setSearchResults(searchResults);
 
-        log.debug(
-            ObjectUtils.isNotEmpty(paginationOffset)
-                ? String.format(
-                    "EntitySearchService.executeSearchQuery(), paginationOffset: %d",
-                    model.getNumberOfPages()
-                )
-                : "EntitySearchService.executeSearchQuery(), paginationOffset: isEmpty"
-        );
-        if (ObjectUtils.isNotEmpty(paginationOffset)) {
+        if (providedPageSize != null && paginationOffset != null) {
             final long numberOfTotalHits = searchResult.total().hitCount();
-            final var numberOfPages = calculateNumberOfPages(numberOfTotalHits, pageSize);
+            final var numberOfPages = calculateNumberOfPages(numberOfTotalHits, providedPageSize);
             model.setNumberOfPages(numberOfPages);
             model.setPage(Math.min(searchQueryAndSortingInformation.getPage(), numberOfPages));
         }
-        log.debug(
-            String.format(
-                "EntitySearchService.executeSearchQuery(), model.getNumberOfPages(): %d",
-                model.getNumberOfPages()
-            )
-        );
-        log.debug(String.format("EntitySearchService.executeSearchQuery(), model.getPage(): %d", model.getPage()));
+        log.debug("EntitySearchService.executeSearchQuery(), model.getNumberOfPages(): {}", model.getNumberOfPages());
+        log.debug("EntitySearchService.executeSearchQuery(), model.getPage(): {}", model.getPage());
+
         return model;
     }
 
@@ -589,16 +584,12 @@ public class EntitySearchService {
     ) {
         final var page = searchQueryAndSortingModel.getPage();
         final var pageSize = searchQueryAndSortingModel.getPageSize();
-        log.debug(
-            String.format("EntitySearchService.calculateOffsetOrNullIfNoPaginationRequired, pageSize: %d", pageSize)
-        );
         final Integer offset;
         if (ObjectUtils.isNotEmpty(page) && ObjectUtils.isNotEmpty(pageSize)) {
             offset = (page - 1) * pageSize;
         } else {
             offset = null;
         }
-        log.debug(String.format("EntitySearchService.calculateOffsetOrNullIfNoPaginationRequired, offset: %d", offset));
         return offset;
     }
 
@@ -609,7 +600,6 @@ public class EntitySearchService {
         } else {
             numberOfPages = numberOfTotalHits / pageSize + 1;
         }
-        log.debug(String.format("EntitySearchService.calculateNumberOfPages, numberOfPages: %d", numberOfPages));
         return numberOfPages;
     }
 }

--- a/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
@@ -49,7 +49,7 @@ public class EntitySearchService {
     @PersistenceContext
     private EntityManager entityManager;
 
-    @Value("${search.durationFetch}")
+    @Value("${spring.jpa.properties.hibernate.search.backend.read_timeout}")
     final Long durationFetch = 30000L;
 
     @Value("${search.totalHitCountThreshold}")

--- a/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
@@ -49,10 +49,10 @@ public class EntitySearchService {
     private EntityManager entityManager;
 
     @Value("${search.durationFetch}")
-    final Long durationFetch = 60000L;
+    final Long durationFetch = 30000L;
 
     @Value("${search.totalHitCountThreshold}")
-    final int totalHitCountThreshold = 1000;
+    final int totalHitCountThreshold = 500;
 
     private static final int maximumPageSize = 500;
 

--- a/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
@@ -501,7 +501,7 @@ public class EntitySearchService {
         final int pageSize = ObjectUtils.isNotEmpty(paginationOffset)
             ? searchQueryAndSortingInformation.getPageSize()
             : Math.min(maximumPageSize, searchQueryAndSortingInformation.getPageSize());
-
+        log.debug(String.format("EntitySearchService.executeSearchQuery(), pageSize: %d", pageSize));
         // Setzt ein Timeout von durationFetch
         final SearchResult<BaseEntity> searchResult = searchQueryOptions
             .failAfter(Duration.ofMillis(durationFetch).toMillis(), TimeUnit.MILLISECONDS) // Timeout setzen
@@ -516,13 +516,27 @@ public class EntitySearchService {
         final var model = new SearchResultsModel();
         model.setSearchResults(searchResults);
 
+        log.debug(
+            ObjectUtils.isNotEmpty(paginationOffset)
+                ? String.format(
+                    "EntitySearchService.executeSearchQuery(), paginationOffset: %d",
+                    model.getNumberOfPages()
+                )
+                : "EntitySearchService.executeSearchQuery(), paginationOffset: isEmpty"
+        );
         if (ObjectUtils.isNotEmpty(paginationOffset)) {
             final long numberOfTotalHits = searchResult.total().hitCount();
             final var numberOfPages = calculateNumberOfPages(numberOfTotalHits, pageSize);
             model.setNumberOfPages(numberOfPages);
             model.setPage(Math.min(searchQueryAndSortingInformation.getPage(), numberOfPages));
         }
-
+        log.debug(
+            String.format(
+                "EntitySearchService.executeSearchQuery(), model.getNumberOfPages(): %d",
+                model.getNumberOfPages()
+            )
+        );
+        log.debug(String.format("EntitySearchService.executeSearchQuery(), model.getPage(): %d", model.getPage()));
         return model;
     }
 
@@ -575,12 +589,16 @@ public class EntitySearchService {
     ) {
         final var page = searchQueryAndSortingModel.getPage();
         final var pageSize = searchQueryAndSortingModel.getPageSize();
+        log.debug(
+            String.format("EntitySearchService.calculateOffsetOrNullIfNoPaginationRequired, pageSize: %d", pageSize)
+        );
         final Integer offset;
         if (ObjectUtils.isNotEmpty(page) && ObjectUtils.isNotEmpty(pageSize)) {
             offset = (page - 1) * pageSize;
         } else {
             offset = null;
         }
+        log.debug(String.format("EntitySearchService.calculateOffsetOrNullIfNoPaginationRequired, offset: %d", offset));
         return offset;
     }
 
@@ -591,6 +609,7 @@ public class EntitySearchService {
         } else {
             numberOfPages = numberOfTotalHits / pageSize + 1;
         }
+        log.debug(String.format("EntitySearchService.calculateNumberOfPages, numberOfPages: %d", numberOfPages));
         return numberOfPages;
     }
 }

--- a/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
@@ -12,10 +12,12 @@ import de.muenchen.isi.infrastructure.entity.enums.lookup.UncertainBoolean;
 import de.muenchen.isi.security.AuthenticationUtils;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -88,7 +90,6 @@ public class EntitySearchService {
                             .simpleQueryString()
                             .fields(searchableAttributes)
                             .matching(adaptedSearchQuery)
-                            // Es werden nur die Entitäten als Suchergebnis zurückgegeben, welche alle Suchwörter der Suchquery beinhalten.
                             .defaultOperator(BooleanOperator.AND);
                     } else {
                         // Zurückgeben aller Entitäten.
@@ -104,6 +105,8 @@ public class EntitySearchService {
                         function
                     );
             })
+            // Setze eine Begrenzung für `trackTotalHits`, um Performance zu verbessern
+            .totalHitCountThreshold(1000) // Zählt max. 1000 Treffer, vermeidet lange Berechnungen
             // Sortierung der Suchergebnisse.
             // https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#query-sorting
             .sort(function -> {
@@ -117,6 +120,7 @@ public class EntitySearchService {
                     return function.field("lastModifiedDateTime").order(sortOrder);
                 }
             });
+
         return this.executeSearchQuery(searchQueryAndSortingInformation, searchQueryOptions);
     }
 
@@ -192,7 +196,7 @@ public class EntitySearchService {
                 root.add(
                     function
                         .bool()
-                        .must(b -> {
+                        .filter(b -> {
                             var theBool = b.bool();
                             for (final var value : valueList) {
                                 theBool = theBool.should(function.match().field(keyAttribute).matching(value));
@@ -482,16 +486,18 @@ public class EntitySearchService {
         final SearchQueryAndSortingModel searchQueryAndSortingInformation,
         final SearchQueryOptionsStep searchQueryOptions
     ) {
-        // Der Offset oder null falls keine Offsetberechnung möglich ist.
-        // Ist keine Offsetberechnung möglich, so wird auch keine paginierte Suche durchgeführt.
         final Integer paginationOffset = calculateOffsetOrNullIfNoPaginationRequired(searchQueryAndSortingInformation);
 
-        // Ausführen einer paginierten oder nicht-paginierten Suche.
-        final SearchResult<BaseEntity> searchResult = ObjectUtils.isNotEmpty(paginationOffset)
-            ? searchQueryOptions.fetch(paginationOffset, searchQueryAndSortingInformation.getPageSize())
-            : searchQueryOptions.fetchAll();
+        // **Maximale Größe auf 500 setzen, falls keine Paginierung definiert ist**
+        final int pageSize = ObjectUtils.isNotEmpty(paginationOffset)
+            ? searchQueryAndSortingInformation.getPageSize()
+            : Math.min(500, searchQueryAndSortingInformation.getPageSize());
 
-        // Suchergebnisse extrahieren und zurückgeben.
+        // **Setze ein Timeout von 10 Sekunden**
+        final SearchResult<BaseEntity> searchResult = searchQueryOptions
+            .failAfter(Duration.ofSeconds(30).toSeconds(), TimeUnit.SECONDS) // Timeout setzen
+            .fetch(paginationOffset != null ? paginationOffset : 0, pageSize);
+
         final var searchResults = searchResult
             .hits()
             .stream()
@@ -500,18 +506,14 @@ public class EntitySearchService {
 
         final var model = new SearchResultsModel();
         model.setSearchResults(searchResults);
-        if (ObjectUtils.isNotEmpty(paginationOffset)) {
+
+        if (paginationOffset != null) {
             final long numberOfTotalHits = searchResult.total().hitCount();
-            final var numberOfPages = calculateNumberOfPages(
-                numberOfTotalHits,
-                searchQueryAndSortingInformation.getPageSize()
-            );
+            final var numberOfPages = calculateNumberOfPages(numberOfTotalHits, pageSize);
             model.setNumberOfPages(numberOfPages);
-            final var currentPage = searchQueryAndSortingInformation.getPage() > numberOfPages
-                ? numberOfPages
-                : searchQueryAndSortingInformation.getPage();
-            model.setPage(currentPage);
+            model.setPage(Math.min(searchQueryAndSortingInformation.getPage(), numberOfPages));
         }
+
         return model;
     }
 

--- a/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java
@@ -32,6 +32,7 @@ import org.hibernate.search.engine.search.predicate.dsl.SimpleBooleanPredicateCl
 import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
 import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.util.common.SearchTimeoutException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -53,8 +54,6 @@ public class EntitySearchService {
 
     @Value("${search.totalHitCountThreshold}")
     final int totalHitCountThreshold = 500;
-
-    private static final int maximumPageSize = 500;
 
     /**
      * Diese Methode führt die paginierte Entitätssuche für die im Methodenparameter gegebenen Informationen durch.
@@ -496,43 +495,45 @@ public class EntitySearchService {
         final SearchQueryOptionsStep searchQueryOptions
     ) {
         final Integer paginationOffset = calculateOffsetOrNullIfNoPaginationRequired(searchQueryAndSortingInformation);
-        final Integer providedPageSize = searchQueryAndSortingInformation.getPageSize();
-        final SearchResult<BaseEntity> searchResult;
+        try {
+            // Ausführen einer paginierten oder nicht-paginierten Suche.
+            final SearchResult<BaseEntity> searchResult = ObjectUtils.isNotEmpty(paginationOffset)
+                ? searchQueryOptions
+                    .failAfter(Duration.ofMillis(durationFetch).toMillis(), TimeUnit.MILLISECONDS)
+                    .fetch(paginationOffset, searchQueryAndSortingInformation.getPageSize())
+                : searchQueryOptions
+                    .failAfter(Duration.ofMillis(durationFetch).toMillis(), TimeUnit.MILLISECONDS)
+                    .fetchAll();
 
-        if (providedPageSize == null) {
-            log.debug("No pageSize provided, executing non-paginated search with fetchAll()");
-            searchResult = searchQueryOptions
-                .failAfter(Duration.ofMillis(durationFetch).toMillis(), TimeUnit.MILLISECONDS)
-                .fetchAll();
-        } else {
-            final int pageSize = (paginationOffset != null)
-                ? providedPageSize
-                : Math.min(maximumPageSize, providedPageSize);
-            log.debug("EntitySearchService.executeSearchQuery(), pageSize: {}", pageSize);
-            searchResult = searchQueryOptions
-                .failAfter(Duration.ofMillis(durationFetch).toMillis(), TimeUnit.MILLISECONDS)
-                .fetch(paginationOffset != null ? paginationOffset : 0, pageSize);
+            final var searchResults = searchResult
+                .hits()
+                .stream()
+                .map(searchDomainMapper::entity2SearchResultModel)
+                .collect(Collectors.toList());
+
+            final var model = new SearchResultsModel();
+            model.setSearchResults(searchResults);
+
+            if (searchQueryAndSortingInformation.getPageSize() != null && paginationOffset != null) {
+                final long numberOfTotalHits = searchResult.total().hitCount();
+                final var numberOfPages = calculateNumberOfPages(
+                    numberOfTotalHits,
+                    searchQueryAndSortingInformation.getPageSize()
+                );
+                model.setNumberOfPages(numberOfPages);
+                model.setPage(Math.min(searchQueryAndSortingInformation.getPage(), numberOfPages));
+            }
+            return model;
+        } catch (SearchTimeoutException exception) {
+            log.error(
+                "EntitySearchService.executeSearchQuery(), exception: {}, durationFetch: {}, paginationOffset: {}, pageSize: {}",
+                exception.getMessage(),
+                durationFetch,
+                paginationOffset,
+                searchQueryAndSortingInformation.getPageSize()
+            );
+            throw new SearchTimeoutException(exception.getMessage());
         }
-
-        final var searchResults = searchResult
-            .hits()
-            .stream()
-            .map(searchDomainMapper::entity2SearchResultModel)
-            .collect(Collectors.toList());
-
-        final var model = new SearchResultsModel();
-        model.setSearchResults(searchResults);
-
-        if (providedPageSize != null && paginationOffset != null) {
-            final long numberOfTotalHits = searchResult.total().hitCount();
-            final var numberOfPages = calculateNumberOfPages(numberOfTotalHits, providedPageSize);
-            model.setNumberOfPages(numberOfPages);
-            model.setPage(Math.min(searchQueryAndSortingInformation.getPage(), numberOfPages));
-        }
-        log.debug("EntitySearchService.executeSearchQuery(), model.getNumberOfPages(): {}", model.getNumberOfPages());
-        log.debug("EntitySearchService.executeSearchQuery(), model.getPage(): {}", model.getPage());
-
-        return model;
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,10 @@ hibernate:
       connection_timeout : ${spring.jpa.properties.hibernate.search.backend.connection_timeout}
       read_timeout: ${spring.jpa.properties.hibernate.search.backend.read_timeout}
 
+search:
+  durationFetch: 30000
+  totalHitCountThreshold: 1000
+
 server:
   shutdown: "graceful"
   port: 8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,10 +15,6 @@ hibernate:
       connection_timeout : ${spring.jpa.properties.hibernate.search.backend.connection_timeout}
       read_timeout: ${spring.jpa.properties.hibernate.search.backend.read_timeout}
 
-search:
-  durationFetch: 30000
-  totalHitCountThreshold: 1000
-
 server:
   shutdown: "graceful"
   port: 8080

--- a/src/test/resources/application-unittest.yml
+++ b/src/test/resources/application-unittest.yml
@@ -1,3 +1,7 @@
+search:
+  durationFetch: 30000
+  totalHitCountThreshold: 1000
+
 spring:
 
   # Spring data rest

--- a/src/test/resources/application-unittest.yml
+++ b/src/test/resources/application-unittest.yml
@@ -1,5 +1,4 @@
 search:
-  durationFetch: 30000
   totalHitCountThreshold: 1000
 
 spring:


### PR DESCRIPTION
**Description**

## Verwendung von filter anstelle von must in booleschen Abfragen
Durch den Einsatz von filter-Klauseln werden Dokumente gefiltert, ohne ihre Relevanzbewertung zu beeinflussen. Dies führt zu einer besseren Abfrageleistung, da Filterergebnisse zwischengespeichert werden können und nicht erneut berechnet werden müssen.
📌 Quelle: [stackoverflow](https://stackoverflow.com/questions/43349044/what-is-the-difference-between-must-and-filter-in-query-dsl-in-elasticsearch)– Unterschied zwischen must und filter
Code-Änderung in createFilterGemeinsameAttribute:  https://github.com/it-at-m/isi-backend/blob/de5c97809b78b24427b84d211db53b7fbb807093/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java#L203

## Setzen eines Timeouts mit der Methode failAfter
Um zu vermeiden, dass lange Abfragen das System blockieren, wird die maximale Abfragezeit auf 60 Sekunden begrenzt. Falls diese Zeit überschritten wird, wird die Suche automatisch abgebrochen und eine SearchTimeoutException ausgelöst.
📌 Quelle: [Hibernate Search Doku](https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/?utm_source=chatgpt.com#search-dsl-query-timeout-failafter) – failAfter
Code Änderung in executeSearchQuery: 
https://github.com/it-at-m/isi-backend/blob/de5c97809b78b24427b84d211db53b7fbb807093/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java#L51-L52
https://github.com/it-at-m/isi-backend/blob/de5c97809b78b24427b84d211db53b7fbb807093/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java#L502


## Begrenzung der Trefferzählung mit totalHitCountThreshold(1000)
Standardmäßig zählt Hibernate Search alle Treffer, was sehr langsam sein kann. Mit totalHitCountThreshold(1000) wird die Trefferzählung auf maximal 1000 begrenzt. Falls mehr als 1000 Ergebnisse existieren, gibt Hibernate Search nur eine untere Schätzung zurück, wodurch die Abfrage wesentlich schneller wird.
📌 Quelle: [Hibernate Search Doku](https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/?utm_source=chatgpt.com#search-dsl-query-total-hits-threshold) – totalHitCountThreshold
Code-Änderung in searchForEntities: https://github.com/it-at-m/isi-backend/blob/de5c97809b78b24427b84d211db53b7fbb807093/src/main/java/de/muenchen/isi/domain/service/search/EntitySearchService.java#L113

**Reference**

Issues #XXX
