### PR TITLE
ISI-1838-Report-Bauratendatei-geloeschte-Abfrage-noch-vorhanden

### DIFF
--- a/src/main/java/de/muenchen/isi/api/controller/BauvorhabenController.java
+++ b/src/main/java/de/muenchen/isi/api/controller/BauvorhabenController.java
@@ -243,7 +243,7 @@ public class BauvorhabenController {
     )
     @PreAuthorize("hasAuthority(T(de.muenchen.isi.security.AuthoritiesEnum).ISI_BACKEND_DELETE_BAUVORHABEN.name())")
     public ResponseEntity<Void> deleteBauvorhaben(@PathVariable @NotNull final UUID id)
-        throws EntityNotFoundException, EntityIsReferencedException {
+        throws EntityNotFoundException, EntityIsReferencedException, ReportingException {
         this.bauvorhabenService.deleteBauvorhaben(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/de/muenchen/isi/domain/service/BauvorhabenService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/BauvorhabenService.java
@@ -162,13 +162,16 @@ public class BauvorhabenService {
      * @param id zum Identifizieren des {@link BauvorhabenModel}.
      * @throws EntityNotFoundException     falls das Bauvorhaben identifiziert durch die {@link BauvorhabenModel#getId()} nicht gefunden wird.
      * @throws EntityIsReferencedException falls das {@link BauvorhabenModel} in einer Abfrage referenziert wird.
+     * @throws ReportingException          falls bei der Übermittlung an die Reportingschnittstelle ein Fehler auftritt.
      */
-    public void deleteBauvorhaben(final UUID id) throws EntityNotFoundException, EntityIsReferencedException {
+    public void deleteBauvorhaben(final UUID id)
+        throws EntityNotFoundException, EntityIsReferencedException, ReportingException {
         final var bauvorhaben = this.getBauvorhabenById(id);
         this.throwEntityIsReferencedExceptionWhenAbfrageIsReferencingBauvorhaben(bauvorhaben);
         this.throwEntityIsReferencedExceptionWhenInfrastruktureinrichtungIsReferencingBauvorhaben(bauvorhaben);
         this.kommentarRepository.deleteAllByBauvorhabenId(id);
         this.bauvorhabenRepository.deleteById(id);
+        etlInterfaceService.etlInterfaceTriggerDeleteBauvorhabenJob(id);
     }
 
     /**

--- a/src/main/java/de/muenchen/isi/domain/service/etlInterface/EtlInterfaceService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/etlInterface/EtlInterfaceService.java
@@ -63,10 +63,10 @@ public class EtlInterfaceService {
     }
 
     /**
-     * Ruft die Reporting-EAI Schnittstelle auf, damit ein ETL-Job zur Übertragung eine Bauvorhabens
+     * Ruft die Reporting-EAI Schnittstelle auf, damit ein ETL-Job zur Übertragung eines Bauvorhabens
      * vom Backend zur Reporting DB aufgerufen wird
      *
-     * @param id ID derInfrastruktureinrichtung
+     * @param id ID des Bauvorhabens
      * @throws ReportingException falls der Aufruf fehlgeschlagen ist.
      */
     public void etlInterfaceTriggerBauvorhabenJob(final UUID id) throws ReportingException {
@@ -74,6 +74,18 @@ public class EtlInterfaceService {
             "importFromBackend/bauvorhaben/Job_Import_Bauvorhaben.kjb",
             id
         );
+        this.etlInterfaceTriggerJob(etlTriggerJobDto);
+    }
+
+    /**
+     * Ruft die Reporting-EAI Schnittstelle auf, damit ein ETL-Job zur Löschung eines Bauvorhabens
+     * in der Reporting DB aufgerufen wird
+     *
+     * @param id ID des Bauvorhabens
+     * @throws ReportingException falls der Aufruf fehlgeschlagen ist.
+     */
+    public void etlInterfaceTriggerDeleteBauvorhabenJob(final UUID id) throws ReportingException {
+        final EtlTriggerJobDto etlTriggerJobDto = this.prepareJob("delete/bauvorhaben/Job_Delete_Bauvorhaben.kjb", id);
         this.etlInterfaceTriggerJob(etlTriggerJobDto);
     }
 

--- a/src/test/java/de/muenchen/isi/domain/service/BauvorhabenServiceTest.java
+++ b/src/test/java/de/muenchen/isi/domain/service/BauvorhabenServiceTest.java
@@ -605,7 +605,7 @@ public class BauvorhabenServiceTest {
     }
 
     @Test
-    void deleteBauvorhaben() throws EntityNotFoundException, EntityIsReferencedException {
+    void deleteBauvorhaben() throws EntityNotFoundException, EntityIsReferencedException, ReportingException {
         final UUID id = UUID.randomUUID();
 
         final Bauvorhaben entity = new Bauvorhaben();


### PR DESCRIPTION
**Description**

Fehlerbehebung bei Bauvorhaben in der Reporting-DB: Wird ein Bauvorhaben im Backend gelöscht, so wird durch einen entsprechenden EAI-Aufruf das Bauvorhaben auch in der Reporting DB gelöscht.

**Reference**

Issues #ISI-1838
