### PR TITLE
202603-Correct-Spring-Cloud-Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.cloud.version>2025.1.1</spring.cloud.version>
+        <spring.cloud.version>2025.0.1</spring.cloud.version>
         <spring.boot.version>3.5.13</spring.boot.version>
         <spring.boot.test>3.5.13</spring.boot.test>
         <apache.commons.text>1.15.0</apache.commons.text>


### PR DESCRIPTION
**Description**

_spring.cloud.version_ korrigiert, siehe: https://spring.io/projects/spring-cloud

<img width="840" height="167" alt="grafik" src="https://github.com/user-attachments/assets/03132b76-1a5a-448f-b186-782d9c10be48" />


**Reference**

Issues #202603-Correct-Spring-Cloud-Version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Spring Cloud framework dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->