### PR TITLE
ISI2-311-Erweiterung-Kommentarfeld-im-Bauvorhaben

### DIFF
--- a/src/main/java/de/muenchen/isi/api/dto/common/KommentarDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/common/KommentarDto.java
@@ -1,10 +1,11 @@
 package de.muenchen.isi.api.dto.common;
 
 import de.muenchen.isi.api.dto.BaseEntityDto;
+import de.muenchen.isi.api.dto.common.BearbeitendePersonDto;
 import de.muenchen.isi.api.dto.filehandling.DokumentDto;
 import de.muenchen.isi.api.validation.HasAllowedNumberOfDocuments;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -15,11 +16,12 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 public abstract class KommentarDto extends BaseEntityDto {
 
-    @Size(max = 32, message = "Es sind maximal {max} Zeichen erlaubt")
-    private String datum;
+    private LocalDate erstellungsdatum;
 
     private String text;
 
     @HasAllowedNumberOfDocuments
     private List<@Valid DokumentDto> dokumente;
+
+    private BearbeitendePersonDto bearbeitendePerson;
 }

--- a/src/main/java/de/muenchen/isi/domain/model/common/KommentarModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/common/KommentarModel.java
@@ -1,7 +1,9 @@
 package de.muenchen.isi.domain.model.common;
 
 import de.muenchen.isi.domain.model.BaseEntityModel;
+import de.muenchen.isi.domain.model.common.BearbeitendePersonModel;
 import de.muenchen.isi.domain.model.filehandling.DokumentModel;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -12,9 +14,11 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 public abstract class KommentarModel extends BaseEntityModel {
 
-    private String datum;
+    private LocalDate erstellungsdatum;
 
     private String text;
 
     private List<DokumentModel> dokumente;
+
+    private BearbeitendePersonModel bearbeitendePerson;
 }

--- a/src/main/java/de/muenchen/isi/domain/service/common/KommentarService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/common/KommentarService.java
@@ -114,7 +114,7 @@ public class KommentarService {
                 savedEntity.getBauvorhaben().getId(),
                 savedEntity.getBauvorhaben().getNameVorhaben(),
                 savedEntity.getText(),
-                savedEntity.getDatum(),
+                savedEntity.getErstellungsdatum(),
                 isNew
             );
         }

--- a/src/main/java/de/muenchen/isi/domain/service/email/SendKommentarBauvorhabenNotificationService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/email/SendKommentarBauvorhabenNotificationService.java
@@ -66,7 +66,7 @@ public class SendKommentarBauvorhabenNotificationService {
             bauvorhabenId,
             bauvorhabenName,
             kommentarText,
-            kommentarDatum.format(DateTimeFormatter.ofPattern("dd.MM.yyyy")),
+            kommentarDatum != null ? kommentarDatum.format(DateTimeFormatter.ofPattern("dd.MM.yyyy")) : null,
             isNew
         );
         mailSenderRepository.sendMail(List.of(receiverKommentarBauvorhaben), subject, text);

--- a/src/main/java/de/muenchen/isi/domain/service/email/SendKommentarBauvorhabenNotificationService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/email/SendKommentarBauvorhabenNotificationService.java
@@ -3,6 +3,8 @@ package de.muenchen.isi.domain.service.email;
 import de.muenchen.isi.infrastructure.entity.Abfrage;
 import de.muenchen.isi.infrastructure.repository.AbfrageRepository;
 import de.muenchen.isi.infrastructure.repository.email.MailSenderRepository;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -41,7 +43,7 @@ public class SendKommentarBauvorhabenNotificationService {
         final UUID bauvorhabenId,
         final String bauvorhabenName,
         final String kommentarText,
-        final String kommentarDatum,
+        final LocalDate kommentarDatum,
         final boolean isNew
     ) {
         sendKommentarBauvorhabenNotification(bauvorhabenId, bauvorhabenName, kommentarText, kommentarDatum, isNew);
@@ -51,7 +53,7 @@ public class SendKommentarBauvorhabenNotificationService {
         final UUID bauvorhabenId,
         final String bauvorhabenName,
         final String kommentarText,
-        final String kommentarDatum,
+        final LocalDate kommentarDatum,
         final boolean isNew
     ) {
         if (StringUtils.isEmpty(receiverKommentarBauvorhaben)) {
@@ -60,7 +62,13 @@ public class SendKommentarBauvorhabenNotificationService {
         final var subjectAction = isNew ? "Neuer" : "Aktualisierter";
         final var subject =
             "ISI - " + subjectAction + " Kommentar zum Bauvorhaben: " + StringUtils.defaultIfEmpty(bauvorhabenName, "");
-        final var text = buildEmailText(bauvorhabenId, bauvorhabenName, kommentarText, kommentarDatum, isNew);
+        final var text = buildEmailText(
+            bauvorhabenId,
+            bauvorhabenName,
+            kommentarText,
+            kommentarDatum.format(DateTimeFormatter.ofPattern("dd.MM.yyyy")),
+            isNew
+        );
         mailSenderRepository.sendMail(List.of(receiverKommentarBauvorhaben), subject, text);
     }
 

--- a/src/main/java/de/muenchen/isi/infrastructure/adapter/listener/KommentarListener.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/adapter/listener/KommentarListener.java
@@ -1,0 +1,24 @@
+package de.muenchen.isi.infrastructure.adapter.listener;
+
+import de.muenchen.isi.infrastructure.entity.common.Kommentar;
+import de.muenchen.isi.security.AuthenticationUtils;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KommentarListener {
+
+    private final AuthenticationUtils authenticationUtils;
+
+    @PrePersist
+    @PreUpdate
+    public void beforeSave(final Kommentar kommentar) {
+        final var bearbeitendePerson = authenticationUtils.getBearbeitendePerson();
+        kommentar.setBearbeitendePerson(bearbeitendePerson);
+    }
+}

--- a/src/main/java/de/muenchen/isi/infrastructure/adapter/listener/KommentarListener.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/adapter/listener/KommentarListener.java
@@ -4,6 +4,7 @@ import de.muenchen.isi.infrastructure.entity.common.Kommentar;
 import de.muenchen.isi.security.AuthenticationUtils;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -19,6 +20,9 @@ public class KommentarListener {
     @PreUpdate
     public void beforeSave(final Kommentar kommentar) {
         final var bearbeitendePerson = authenticationUtils.getBearbeitendePerson();
+        if (kommentar.getErstellungsdatum() == null) {
+            kommentar.setErstellungsdatum(LocalDate.now());
+        }
         kommentar.setBearbeitendePerson(bearbeitendePerson);
     }
 }

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/common/Kommentar.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/common/Kommentar.java
@@ -37,6 +37,7 @@ import lombok.ToString;
 )
 public class Kommentar extends BaseEntity {
 
+    @Column(updatable = false)
     private LocalDate erstellungsdatum;
 
     @Column(columnDefinition = "text")

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/common/Kommentar.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/common/Kommentar.java
@@ -1,24 +1,31 @@
 package de.muenchen.isi.infrastructure.entity.common;
 
+import de.muenchen.isi.infrastructure.adapter.listener.KommentarListener;
 import de.muenchen.isi.infrastructure.entity.BaseEntity;
 import de.muenchen.isi.infrastructure.entity.Bauvorhaben;
 import de.muenchen.isi.infrastructure.entity.filehandling.Dokument;
 import de.muenchen.isi.infrastructure.entity.infrastruktureinrichtung.Infrastruktureinrichtung;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 @Entity
+@EntityListeners({ KommentarListener.class })
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
@@ -30,8 +37,7 @@ import lombok.ToString;
 )
 public class Kommentar extends BaseEntity {
 
-    @Column(length = 32)
-    private String datum;
+    private LocalDate erstellungsdatum;
 
     @Column(columnDefinition = "text")
     private String text;
@@ -47,4 +53,17 @@ public class Kommentar extends BaseEntity {
     @OneToMany(cascade = { CascadeType.ALL }, fetch = FetchType.LAZY, orphanRemoval = true)
     @JoinColumn(name = "kommentar_id")
     private List<Dokument> dokumente;
+
+    @Embedded
+    @AttributeOverrides(
+        {
+            @AttributeOverride(name = "name", column = @Column(name = "bearbeitende_person_name")),
+            @AttributeOverride(name = "email", column = @Column(name = "bearbeitende_person_email")),
+            @AttributeOverride(
+                name = "organisationseinheit",
+                column = @Column(name = "bearbeitende_person_organisationseinheit")
+            ),
+        }
+    )
+    private BearbeitendePerson bearbeitendePerson;
 }

--- a/src/main/resources/db/migration/V38__ISI2-311_Kommentare_Anpassungen.sql
+++ b/src/main/resources/db/migration/V38__ISI2-311_Kommentare_Anpassungen.sql
@@ -1,0 +1,23 @@
+--
+--
+-- Neue Felder Im Kommentar im Bauvorhaben
+--      Letzte Bearbeitung
+--      Letzter Bearbeiter
+--      Datum -> Erstellungsdatum
+--
+--
+BEGIN;
+
+ALTER TABLE IF EXISTS isidbuser.kommentar
+    ADD COLUMN erstellungsdatum timestamp without time zone,
+    ADD COLUMN bearbeitende_person_email character varying(255),
+    ADD COLUMN bearbeitende_person_name character varying(255),
+    ADD COLUMN bearbeitende_person_organisationseinheit character varying(255);
+
+update isidbuser.kommentar
+set erstellungsdatum = now(), text = kommentar.datum||chr(13)||text, bearbeitende_person_name = 'ITM-ISI';
+
+ALTER TABLE IF EXISTS isidbuser.kommentar
+    DROP COLUMN IF EXISTS datum;
+
+END;

--- a/src/main/resources/db/migration/V38__ISI2-311_Kommentare_Anpassungen.sql
+++ b/src/main/resources/db/migration/V38__ISI2-311_Kommentare_Anpassungen.sql
@@ -9,7 +9,7 @@
 BEGIN;
 
 ALTER TABLE IF EXISTS isidbuser.kommentar
-    ADD COLUMN erstellungsdatum date,
+    ADD COLUMN erstellungsdatum timestamp without time zone,
     ADD COLUMN bearbeitende_person_email character varying(255),
     ADD COLUMN bearbeitende_person_name character varying(255),
     ADD COLUMN bearbeitende_person_organisationseinheit character varying(255);

--- a/src/main/resources/db/migration/V38__ISI2-311_Kommentare_Anpassungen.sql
+++ b/src/main/resources/db/migration/V38__ISI2-311_Kommentare_Anpassungen.sql
@@ -9,13 +9,15 @@
 BEGIN;
 
 ALTER TABLE IF EXISTS isidbuser.kommentar
-    ADD COLUMN erstellungsdatum timestamp without time zone,
+    ADD COLUMN erstellungsdatum date,
     ADD COLUMN bearbeitende_person_email character varying(255),
     ADD COLUMN bearbeitende_person_name character varying(255),
     ADD COLUMN bearbeitende_person_organisationseinheit character varying(255);
 
 update isidbuser.kommentar
-set erstellungsdatum = now(), text = kommentar.datum||chr(13)||text, bearbeitende_person_name = 'ITM-ISI';
+set erstellungsdatum = CURRENT_DATE,
+    text = CONCAT_WS(chr(10), NULLIF(datum, ''), text),
+    bearbeitende_person_name = 'ITM-ISI';
 
 ALTER TABLE IF EXISTS isidbuser.kommentar
     DROP COLUMN IF EXISTS datum;

--- a/src/test/java/de/muenchen/isi/domain/service/common/KommentarServiceTest.java
+++ b/src/test/java/de/muenchen/isi/domain/service/common/KommentarServiceTest.java
@@ -21,6 +21,7 @@ import de.muenchen.isi.infrastructure.repository.BauvorhabenRepository;
 import de.muenchen.isi.infrastructure.repository.InfrastruktureinrichtungRepository;
 import de.muenchen.isi.infrastructure.repository.common.KommentarRepository;
 import java.lang.reflect.Field;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -87,13 +88,13 @@ class KommentarServiceTest {
         final var bauvorhaben = new Bauvorhaben();
         bauvorhaben.setId(uuidBauvorhaben);
         kommentar1.setId(UUID.randomUUID());
-        kommentar1.setDatum("datum 1");
+        kommentar1.setErstellungsdatum(LocalDate.of(2026, 7, 14));
         kommentar1.setText("text 1");
         kommentar1.setBauvorhaben(bauvorhaben);
 
         final var kommentar2 = new Kommentar();
         kommentar2.setId(UUID.randomUUID());
-        kommentar2.setDatum("datum 2");
+        kommentar2.setErstellungsdatum(LocalDate.of(2026, 8, 1));
         kommentar2.setText("text 2");
         kommentar2.setBauvorhaben(bauvorhaben);
 
@@ -105,13 +106,13 @@ class KommentarServiceTest {
 
         final var kommentar1Model = new KommentarBauvorhabenModel();
         kommentar1Model.setId(kommentar1.getId());
-        kommentar1Model.setDatum("datum 1");
+        kommentar1Model.setErstellungsdatum(LocalDate.of(2026, 7, 14));
         kommentar1Model.setText("text 1");
         kommentar1Model.setBauvorhaben(uuidBauvorhaben);
 
         final var kommentar2Model = new KommentarBauvorhabenModel();
         kommentar2Model.setId(kommentar2.getId());
-        kommentar2Model.setDatum("datum 2");
+        kommentar2Model.setErstellungsdatum(LocalDate.of(2026, 8, 1));
         kommentar2Model.setText("text 2");
         kommentar2Model.setBauvorhaben(uuidBauvorhaben);
 
@@ -129,13 +130,13 @@ class KommentarServiceTest {
         final var infrastruktureinrichtung = new Kinderkrippe();
         infrastruktureinrichtung.setId(uuidInfrastruktureinrichtung);
         kommentar1.setId(UUID.randomUUID());
-        kommentar1.setDatum("datum 1");
+        kommentar1.setErstellungsdatum(LocalDate.of(2026, 7, 14));
         kommentar1.setText("text 1");
         kommentar1.setInfrastruktureinrichtung(infrastruktureinrichtung);
 
         final var kommentar2 = new Kommentar();
         kommentar2.setId(UUID.randomUUID());
-        kommentar2.setDatum("datum 2");
+        kommentar2.setErstellungsdatum(LocalDate.of(2026, 8, 1));
         kommentar2.setText("text 2");
         kommentar2.setInfrastruktureinrichtung(infrastruktureinrichtung);
 
@@ -149,13 +150,13 @@ class KommentarServiceTest {
 
         final var kommentar1Model = new KommentarInfrastruktureinrichtungModel();
         kommentar1Model.setId(kommentar1.getId());
-        kommentar1Model.setDatum("datum 1");
+        kommentar1Model.setErstellungsdatum(LocalDate.of(2026, 7, 14));
         kommentar1Model.setText("text 1");
         kommentar1Model.setInfrastruktureinrichtung(uuidInfrastruktureinrichtung);
 
         final var kommentar2Model = new KommentarInfrastruktureinrichtungModel();
         kommentar2Model.setId(kommentar2.getId());
-        kommentar2Model.setDatum("datum 2");
+        kommentar2Model.setErstellungsdatum(LocalDate.of(2026, 8, 1));
         kommentar2Model.setText("text 2");
         kommentar2Model.setInfrastruktureinrichtung(uuidInfrastruktureinrichtung);
 
@@ -174,7 +175,7 @@ class KommentarServiceTest {
         final var bauvorhaben = new Bauvorhaben();
         bauvorhaben.setId(uuidBauvorhaben);
         kommentar1.setId(UUID.randomUUID());
-        kommentar1.setDatum("datum 1");
+        kommentar1.setErstellungsdatum(LocalDate.of(2026, 7, 14));
         kommentar1.setText("text 1");
         kommentar1.setBauvorhaben(bauvorhaben);
 
@@ -185,7 +186,7 @@ class KommentarServiceTest {
 
         final var kommentar1Model = new KommentarBauvorhabenModel();
         kommentar1Model.setId(kommentar1.getId());
-        kommentar1Model.setDatum("datum 1");
+        kommentar1Model.setErstellungsdatum(LocalDate.of(2026, 7, 14));
         kommentar1Model.setText("text 1");
         kommentar1Model.setBauvorhaben(uuidBauvorhaben);
         assertThat(kommentar1Model, is(result));
@@ -207,13 +208,13 @@ class KommentarServiceTest {
         final var bauvorhaben = new Bauvorhaben();
         bauvorhaben.setId(uuidBauvorhaben);
         kommentar1.setId(UUID.randomUUID());
-        kommentar1.setDatum("datum 1");
+        kommentar1.setErstellungsdatum(LocalDate.of(2026, 7, 14));
         kommentar1.setText("text 1");
         kommentar1.setBauvorhaben(bauvorhaben);
 
         final var kommentar1Model = new KommentarBauvorhabenModel();
         kommentar1Model.setId(kommentar1.getId());
-        kommentar1Model.setDatum("datum 1");
+        kommentar1Model.setErstellungsdatum(LocalDate.of(2026, 7, 14));
         kommentar1Model.setText("text 1");
         kommentar1Model.setBauvorhaben(uuidBauvorhaben);
 
@@ -230,7 +231,7 @@ class KommentarServiceTest {
         Mockito.reset(this.infrastruktureinrichtungRepository, this.bauvorhabenRepository, this.kommentarRepository);
 
         kommentar1 = new Kommentar();
-        kommentar1.setDatum("datum 1");
+        kommentar1.setErstellungsdatum(LocalDate.of(2026, 7, 14));
         kommentar1.setText("text 1");
         kommentar1.setBauvorhaben(null);
         kommentar1.setInfrastruktureinrichtung(null);
@@ -250,13 +251,13 @@ class KommentarServiceTest {
         final var bauvorhaben = new Bauvorhaben();
         bauvorhaben.setId(uuidBauvorhaben);
         kommentar1.setId(UUID.randomUUID());
-        kommentar1.setDatum("datum 1");
+        kommentar1.setErstellungsdatum(LocalDate.of(2026, 7, 14));
         kommentar1.setText("text 1");
         kommentar1.setBauvorhaben(bauvorhaben);
 
         final var kommentar1Model = new KommentarBauvorhabenModel();
         kommentar1Model.setId(kommentar1.getId());
-        kommentar1Model.setDatum("datum 1");
+        kommentar1Model.setErstellungsdatum(LocalDate.of(2026, 7, 14));
         kommentar1Model.setText("text 1");
         kommentar1Model.setBauvorhaben(uuidBauvorhaben);
 

--- a/src/test/java/de/muenchen/isi/domain/service/email/SendKommentarBauvorhabenNotificationServiceTest.java
+++ b/src/test/java/de/muenchen/isi/domain/service/email/SendKommentarBauvorhabenNotificationServiceTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.is;
 import de.muenchen.isi.infrastructure.entity.Baugenehmigungsverfahren;
 import de.muenchen.isi.infrastructure.repository.AbfrageRepository;
 import de.muenchen.isi.infrastructure.repository.email.MailSenderRepository;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -67,7 +68,7 @@ class SendKommentarBauvorhabenNotificationServiceTest {
             bauvorhabenId,
             "Mein Bauvorhaben",
             "Ein Kommentar",
-            "01.06.2026",
+            LocalDate.of(2026, 6, 1),
             true
         );
 
@@ -98,7 +99,7 @@ class SendKommentarBauvorhabenNotificationServiceTest {
             bauvorhabenId,
             "Mein Bauvorhaben",
             "Ein Kommentar",
-            "01.06.2026",
+            LocalDate.of(2026, 6, 1),
             false
         );
 
@@ -128,7 +129,7 @@ class SendKommentarBauvorhabenNotificationServiceTest {
             bauvorhabenId,
             "Mein Bauvorhaben",
             "Ein Kommentar",
-            "01.06.2026",
+            LocalDate.of(2026, 6, 1),
             true
         );
 
@@ -159,7 +160,7 @@ class SendKommentarBauvorhabenNotificationServiceTest {
             bauvorhabenId,
             "Mein Bauvorhaben",
             "Ein Kommentar",
-            "01.06.2026",
+            LocalDate.of(2026, 6, 1),
             true
         );
 

--- a/src/test/java/de/muenchen/isi/infrastructure/adapter/listener/KommentarListenerTest.java
+++ b/src/test/java/de/muenchen/isi/infrastructure/adapter/listener/KommentarListenerTest.java
@@ -32,6 +32,7 @@ class KommentarListenerTest {
         kommentarListener.beforeSave(entityToSave);
 
         final var expected = new Kommentar();
+        expected.setErstellungsdatum(java.time.LocalDate.now());
         final var bearbeitendePerson = new BearbeitendePerson();
         bearbeitendePerson.setName("Rob Winch");
         bearbeitendePerson.setEmail("rob@example.com");

--- a/src/test/java/de/muenchen/isi/infrastructure/adapter/listener/KommentarListenerTest.java
+++ b/src/test/java/de/muenchen/isi/infrastructure/adapter/listener/KommentarListenerTest.java
@@ -1,0 +1,43 @@
+package de.muenchen.isi.infrastructure.adapter.listener;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import de.muenchen.isi.IsiBackendApplication;
+import de.muenchen.isi.TestConstants;
+import de.muenchen.isi.domain.service.transition.MockCustomUser;
+import de.muenchen.isi.infrastructure.entity.common.BearbeitendePerson;
+import de.muenchen.isi.infrastructure.entity.common.Kommentar;
+import org.junit.jupiter.api.Test;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest(classes = { IsiBackendApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles(profiles = { TestConstants.SPRING_UNIT_TEST_PROFILE, TestConstants.SPRING_NO_SECURITY_PROFILE })
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ContextConfiguration
+class KommentarListenerTest {
+
+    @Autowired
+    private KommentarListener kommentarListener;
+
+    @Test
+    @MockCustomUser
+    void beforeSave() {
+        final var entityToSave = new Kommentar();
+        kommentarListener.beforeSave(entityToSave);
+
+        final var expected = new Kommentar();
+        final var bearbeitendePerson = new BearbeitendePerson();
+        bearbeitendePerson.setName("Rob Winch");
+        bearbeitendePerson.setEmail("rob@example.com");
+        bearbeitendePerson.setOrganisationseinheit("IT");
+        expected.setBearbeitendePerson(bearbeitendePerson);
+
+        assertThat(entityToSave, is(expected));
+    }
+}


### PR DESCRIPTION
Umsetzung der Story: [ISI2-311](https://jira.muenchen.de/browse/ISI2-311)

Migration der bestehenden Kommentare:

1. Inhalt von _Datum_ wird als erste Zeile in den Kommentar eingefügt und das Datum des Migrationslaufes als Erstellungsdatum eingetragen
2. Als _Letzter Bearbeiter_ ist **ITM-ISI** eingetragen

Issues #ISI2-120


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comments now record their creation date in a standardized date format.
  * Comments automatically include the responsible editor’s name, email, and organizational unit.
  * Notification emails continue displaying comment dates in the localized `dd.MM.yyyy` format.
* **Data Migration**
  * Existing comments are migrated to the updated date and editor information format.
* **Tests**
  * Added and updated coverage for comment handling, notifications, and editor assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->