### PR TITLE
ISI2-833 Persönliche Filter

### DIFF
--- a/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
+++ b/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
@@ -3,6 +3,8 @@ package de.muenchen.isi.api.controller.search;
 import de.muenchen.isi.api.dto.search.filter.PersonalFilterRequestDto;
 import de.muenchen.isi.api.dto.search.filter.PersonalFilterResponseDto;
 import de.muenchen.isi.api.mapper.PersonalFilterApiMapper;
+import de.muenchen.isi.domain.exception.EntityNotFoundException;
+import de.muenchen.isi.domain.exception.OptimisticLockingException;
 import de.muenchen.isi.domain.service.search.PersonalFilterService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -11,6 +13,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -39,31 +42,34 @@ public class PersonalFilterController {
     }
 
     @GetMapping("/{filterId}")
-    public PersonalFilterResponseDto getByFilterID(@PathVariable @NotNull UUID filterId) {
+    public PersonalFilterResponseDto getByFilterID(@PathVariable @NotNull UUID filterId)
+        throws EntityNotFoundException, IllegalAccessException {
         var responseModel = personalFilterService.getByFilterID(filterId);
         return personalFilterApiMapper.model2Dto(responseModel);
     }
 
+    @Transactional(rollbackFor = OptimisticLockingException.class)
     @PatchMapping("/edit")
     public PersonalFilterResponseDto editFilter(
         @RequestBody @Valid @NotNull PersonalFilterRequestDto personalFilterRequestDto
-    ) {
+    ) throws OptimisticLockingException, EntityNotFoundException, IllegalAccessException {
         var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
         var responseModel = personalFilterService.update(requestModel);
         return personalFilterApiMapper.model2Dto(responseModel);
     }
 
+    @Transactional(rollbackFor = OptimisticLockingException.class)
     @PostMapping("/create")
     public PersonalFilterResponseDto createFilter(
         @RequestBody @Valid @NotNull PersonalFilterRequestDto personalFilterRequestDto
-    ) {
+    ) throws OptimisticLockingException {
         var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
         var responseModel = personalFilterService.save(requestModel);
         return personalFilterApiMapper.model2Dto(responseModel);
     }
 
     @PostMapping("/delete/{filterId}")
-    public void deleteFilter(@PathVariable UUID filterId) {
+    public void deleteFilter(@PathVariable UUID filterId) throws EntityNotFoundException, IllegalAccessException {
         personalFilterService.delete(filterId);
     }
 }

--- a/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
+++ b/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
@@ -56,9 +56,8 @@ public class PersonalFilterController {
         return personalFilterApiMapper.model2Dto(responseModel);
     }
 
-    @PostMapping("/delete")
-    public void deleteFilter(@RequestBody PersonalFilterRequestDto personalFilterRequestDto) {
-        var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
-        personalFilterService.delete(requestModel);
+    @PostMapping("/delete/{filterId}")
+    public void deleteFilter(@PathVariable UUID filterId) {
+        personalFilterService.delete(filterId);
     }
 }

--- a/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
+++ b/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
@@ -6,6 +6,7 @@ import de.muenchen.isi.api.dto.search.filter.PersonalFilterResponseDto;
 import de.muenchen.isi.api.mapper.PersonalFilterApiMapper;
 import de.muenchen.isi.domain.exception.EntityNotFoundException;
 import de.muenchen.isi.domain.exception.OptimisticLockingException;
+import de.muenchen.isi.domain.exception.UserRoleNotAllowedException;
 import de.muenchen.isi.domain.service.search.PersonalFilterService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -56,7 +57,7 @@ public class PersonalFilterController {
             ),
         }
     )
-    public List<PersonalFilterResponseDto> getPersonalFilters() throws IllegalAccessException {
+    public List<PersonalFilterResponseDto> getPersonalFilters() throws UserRoleNotAllowedException {
         var modles = personalFilterService.getPersonalFilters();
         return personalFilterApiMapper.models2Dtos(modles);
     }
@@ -79,7 +80,7 @@ public class PersonalFilterController {
         }
     )
     public PersonalFilterResponseDto getByFilterID(@PathVariable @NotNull UUID filterId)
-        throws EntityNotFoundException, IllegalAccessException {
+        throws EntityNotFoundException, UserRoleNotAllowedException {
         var responseModel = personalFilterService.getByFilterID(filterId);
         return personalFilterApiMapper.model2Dto(responseModel);
     }
@@ -117,7 +118,7 @@ public class PersonalFilterController {
     @PatchMapping("/edit")
     public PersonalFilterResponseDto editFilter(
         @RequestBody @Valid @NotNull PersonalFilterRequestDto personalFilterRequestDto
-    ) throws OptimisticLockingException, EntityNotFoundException, IllegalAccessException {
+    ) throws OptimisticLockingException, EntityNotFoundException, UserRoleNotAllowedException {
         var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
         var responseModel = personalFilterService.update(requestModel);
         return personalFilterApiMapper.model2Dto(responseModel);
@@ -146,7 +147,7 @@ public class PersonalFilterController {
     )
     public ResponseEntity<PersonalFilterResponseDto> createFilter(
         @RequestBody @Valid @NotNull PersonalFilterRequestDto personalFilterRequestDto
-    ) throws OptimisticLockingException, IllegalAccessException {
+    ) throws OptimisticLockingException, UserRoleNotAllowedException {
         var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
         var responseModel = personalFilterService.save(requestModel);
         var dto = personalFilterApiMapper.model2Dto(responseModel);
@@ -170,7 +171,7 @@ public class PersonalFilterController {
         }
     )
     @DeleteMapping("/delete/{filterId}")
-    public void deleteFilter(@PathVariable UUID filterId) throws EntityNotFoundException, IllegalAccessException {
+    public void deleteFilter(@PathVariable UUID filterId) throws EntityNotFoundException, UserRoleNotAllowedException {
         personalFilterService.delete(filterId);
     }
 }

--- a/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
+++ b/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
@@ -5,6 +5,8 @@ import de.muenchen.isi.api.dto.search.filter.PersonalFilterResponseDto;
 import de.muenchen.isi.api.mapper.PersonalFilterApiMapper;
 import de.muenchen.isi.domain.service.search.PersonalFilterService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -37,20 +39,24 @@ public class PersonalFilterController {
     }
 
     @GetMapping("/{filterId}")
-    public PersonalFilterResponseDto getByFilterID(@PathVariable UUID filterId) {
+    public PersonalFilterResponseDto getByFilterID(@PathVariable @NotNull UUID filterId) {
         var responseModel = personalFilterService.getByFilterID(filterId);
         return personalFilterApiMapper.model2Dto(responseModel);
     }
 
     @PatchMapping("/edit")
-    public PersonalFilterResponseDto editFilter(@RequestBody PersonalFilterRequestDto personalFilterRequestDto) {
+    public PersonalFilterResponseDto editFilter(
+        @RequestBody @Valid @NotNull PersonalFilterRequestDto personalFilterRequestDto
+    ) {
         var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
         var responseModel = personalFilterService.update(requestModel);
         return personalFilterApiMapper.model2Dto(responseModel);
     }
 
     @PostMapping("/create")
-    public PersonalFilterResponseDto createFilter(@RequestBody PersonalFilterRequestDto personalFilterRequestDto) {
+    public PersonalFilterResponseDto createFilter(
+        @RequestBody @Valid @NotNull PersonalFilterRequestDto personalFilterRequestDto
+    ) {
         var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
         var responseModel = personalFilterService.save(requestModel);
         return personalFilterApiMapper.model2Dto(responseModel);

--- a/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
+++ b/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
@@ -1,0 +1,63 @@
+package de.muenchen.isi.api.controller.search;
+
+import de.muenchen.isi.api.dto.search.filter.PersonalFilterRequestDto;
+import de.muenchen.isi.api.dto.search.filter.PersonalFilterResponseDto;
+import de.muenchen.isi.api.mapper.PersonalFilterApiMapper;
+import de.muenchen.isi.domain.service.search.PersonalFilterService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/personal-filter")
+@Tag(name = "PersonalFilter", description = "API zum interagieren mit persönlichen Filtern")
+@Validated
+public class PersonalFilterController {
+
+    private final PersonalFilterService personalFilterService;
+
+    private final PersonalFilterApiMapper personalFilterApiMapper;
+
+    @GetMapping
+    public List<PersonalFilterResponseDto> getPersonalFilters() {
+        var modles = personalFilterService.getPersonalFilters();
+        return personalFilterApiMapper.models2Dtos(modles);
+    }
+
+    @GetMapping("/filterid")
+    public PersonalFilterResponseDto getByFilterID(@RequestBody PersonalFilterRequestDto personalFilterRequestDto) {
+        var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
+        var responseModel = personalFilterService.getByFilterID(requestModel);
+        return personalFilterApiMapper.model2Dto(responseModel);
+    }
+
+    @PatchMapping("/edit")
+    public PersonalFilterResponseDto editFilter(@RequestBody PersonalFilterRequestDto personalFilterRequestDto) {
+        var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
+        var responseModel = personalFilterService.update(requestModel);
+        return personalFilterApiMapper.model2Dto(responseModel);
+    }
+
+    @PostMapping("/create")
+    public PersonalFilterResponseDto createFilter(@RequestBody PersonalFilterRequestDto personalFilterRequestDto) {
+        var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
+        var responseModel = personalFilterService.save(requestModel);
+        return personalFilterApiMapper.model2Dto(responseModel);
+    }
+
+    @PostMapping("/delete")
+    public void deleteFilter(@RequestBody PersonalFilterRequestDto personalFilterRequestDto) {
+        var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
+        personalFilterService.delete(requestModel);
+    }
+}

--- a/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
+++ b/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
@@ -36,7 +36,7 @@ public class PersonalFilterController {
     private final PersonalFilterApiMapper personalFilterApiMapper;
 
     @GetMapping
-    public List<PersonalFilterResponseDto> getPersonalFilters() {
+    public List<PersonalFilterResponseDto> getPersonalFilters() throws IllegalAccessException {
         var modles = personalFilterService.getPersonalFilters();
         return personalFilterApiMapper.models2Dtos(modles);
     }
@@ -62,7 +62,7 @@ public class PersonalFilterController {
     @PostMapping("/create")
     public PersonalFilterResponseDto createFilter(
         @RequestBody @Valid @NotNull PersonalFilterRequestDto personalFilterRequestDto
-    ) throws OptimisticLockingException {
+    ) throws OptimisticLockingException, IllegalAccessException {
         var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
         var responseModel = personalFilterService.save(requestModel);
         return personalFilterApiMapper.model2Dto(responseModel);

--- a/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
+++ b/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
@@ -1,11 +1,17 @@
 package de.muenchen.isi.api.controller.search;
 
+import de.muenchen.isi.api.dto.error.InformationResponseDto;
 import de.muenchen.isi.api.dto.search.filter.PersonalFilterRequestDto;
 import de.muenchen.isi.api.dto.search.filter.PersonalFilterResponseDto;
 import de.muenchen.isi.api.mapper.PersonalFilterApiMapper;
 import de.muenchen.isi.domain.exception.EntityNotFoundException;
 import de.muenchen.isi.domain.exception.OptimisticLockingException;
 import de.muenchen.isi.domain.service.search.PersonalFilterService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -13,8 +19,11 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,18 +45,74 @@ public class PersonalFilterController {
     private final PersonalFilterApiMapper personalFilterApiMapper;
 
     @GetMapping
+    @Operation(summary = "Lesen aller persönlichen Filter.")
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(
+                responseCode = "403",
+                description = "FORBIDDEN -> Keine Berechtigung um alle persönlichen Filter anzusehen.",
+                content = @Content(schema = @Schema(implementation = InformationResponseDto.class))
+            ),
+        }
+    )
     public List<PersonalFilterResponseDto> getPersonalFilters() throws IllegalAccessException {
         var modles = personalFilterService.getPersonalFilters();
         return personalFilterApiMapper.models2Dtos(modles);
     }
 
     @GetMapping("/{filterId}")
+    @Operation(summary = "Lesen eines persönlichen Filters.")
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(
+                responseCode = "403",
+                description = "FORBIDDEN -> Keine Berechtigung um diesen persönlichen Filter anzusehen.",
+                content = @Content(schema = @Schema(implementation = InformationResponseDto.class))
+            ),
+            @ApiResponse(
+                responseCode = "404",
+                description = "NOT FOUND -> Persönlicher Filter mit dieser ID nicht vorhanden.",
+                content = @Content(schema = @Schema(implementation = InformationResponseDto.class))
+            ),
+        }
+    )
     public PersonalFilterResponseDto getByFilterID(@PathVariable @NotNull UUID filterId)
         throws EntityNotFoundException, IllegalAccessException {
         var responseModel = personalFilterService.getByFilterID(filterId);
         return personalFilterApiMapper.model2Dto(responseModel);
     }
 
+    @Operation(summary = "Aktualisierung eines persönlichen Filters.")
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "OK -> Persönlicher Filter wurde erfolgreich aktualisiert."
+            ),
+            @ApiResponse(
+                responseCode = "400",
+                description = "BAD_REQUEST -> Persönlicher Filter konnte nicht aktualisiert werden, überprüfen sie die Eingabe.",
+                content = @Content(schema = @Schema(implementation = InformationResponseDto.class))
+            ),
+            @ApiResponse(
+                responseCode = "403",
+                description = "FORBIDDEN -> Keine Berechtigung um diesen persönlicher Filter zu bearbeiten.",
+                content = @Content(schema = @Schema(implementation = InformationResponseDto.class))
+            ),
+            @ApiResponse(
+                responseCode = "404",
+                description = "NOT FOUND -> Persönlicher Filter mit dieser ID nicht vorhanden.",
+                content = @Content(schema = @Schema(implementation = InformationResponseDto.class))
+            ),
+            @ApiResponse(
+                responseCode = "412",
+                description = "PRECONDITION_FAILED -> In der Anwendung ist bereits eine neuere Version der Entität gespeichert.",
+                content = @Content(schema = @Schema(implementation = InformationResponseDto.class))
+            ),
+        }
+    )
     @Transactional(rollbackFor = OptimisticLockingException.class)
     @PatchMapping("/edit")
     public PersonalFilterResponseDto editFilter(
@@ -60,15 +125,51 @@ public class PersonalFilterController {
 
     @Transactional(rollbackFor = OptimisticLockingException.class)
     @PostMapping("/create")
-    public PersonalFilterResponseDto createFilter(
+    @Operation(summary = "Anlegen eines neuen persönlichen Filters")
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "201",
+                description = "CREATED -> Persönlicher Filter wurde erfolgreich erstellt."
+            ),
+            @ApiResponse(
+                responseCode = "400",
+                description = "BAD_REQUEST -> Persönlicher Filter konnte nicht erstellt werden, überprüfen sie die Eingabe.",
+                content = @Content(schema = @Schema(implementation = InformationResponseDto.class))
+            ),
+            @ApiResponse(
+                responseCode = "412",
+                description = "PRECONDITION_FAILED -> In der Anwendung ist bereits eine neuere Version der Entität gespeichert.",
+                content = @Content(schema = @Schema(implementation = InformationResponseDto.class))
+            ),
+        }
+    )
+    public ResponseEntity<PersonalFilterResponseDto> createFilter(
         @RequestBody @Valid @NotNull PersonalFilterRequestDto personalFilterRequestDto
     ) throws OptimisticLockingException, IllegalAccessException {
         var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
         var responseModel = personalFilterService.save(requestModel);
-        return personalFilterApiMapper.model2Dto(responseModel);
+        var dto = personalFilterApiMapper.model2Dto(responseModel);
+        return ResponseEntity.status(HttpStatus.CREATED).body(dto);
     }
 
-    @PostMapping("/delete/{filterId}")
+    @Operation(summary = "Löschen eines persönlichen Filters")
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "204", description = "NO CONTENT"),
+            @ApiResponse(
+                responseCode = "404",
+                description = "NOT FOUND -> Persönlicher Filter mit dieser ID nicht vorhanden.",
+                content = @Content(schema = @Schema(implementation = InformationResponseDto.class))
+            ),
+            @ApiResponse(
+                responseCode = "403",
+                description = "CONFLICT -> Keine Berechtigung zum Löschen dieses persönlichen Filters.",
+                content = @Content(schema = @Schema(implementation = InformationResponseDto.class))
+            ),
+        }
+    )
+    @DeleteMapping("/delete/{filterId}")
     public void deleteFilter(@PathVariable UUID filterId) throws EntityNotFoundException, IllegalAccessException {
         personalFilterService.delete(filterId);
     }

--- a/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
+++ b/src/main/java/de/muenchen/isi/api/controller/search/PersonalFilterController.java
@@ -6,11 +6,13 @@ import de.muenchen.isi.api.mapper.PersonalFilterApiMapper;
 import de.muenchen.isi.domain.service.search.PersonalFilterService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,10 +36,9 @@ public class PersonalFilterController {
         return personalFilterApiMapper.models2Dtos(modles);
     }
 
-    @GetMapping("/filterid")
-    public PersonalFilterResponseDto getByFilterID(@RequestBody PersonalFilterRequestDto personalFilterRequestDto) {
-        var requestModel = personalFilterApiMapper.dto2Model(personalFilterRequestDto);
-        var responseModel = personalFilterService.getByFilterID(requestModel);
+    @GetMapping("/{filterId}")
+    public PersonalFilterResponseDto getByFilterID(@PathVariable UUID filterId) {
+        var responseModel = personalFilterService.getByFilterID(filterId);
         return personalFilterApiMapper.model2Dto(responseModel);
     }
 

--- a/src/main/java/de/muenchen/isi/api/dto/search/filter/FilterSettingsDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/search/filter/FilterSettingsDto.java
@@ -1,0 +1,47 @@
+package de.muenchen.isi.api.dto.search.filter;
+
+import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusAbfrage;
+import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusInfrastruktureinrichtung;
+import de.muenchen.isi.infrastructure.entity.enums.lookup.UncertainBoolean;
+import de.muenchen.isi.infrastructure.entity.enums.lookup.Verfahrensstand;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FilterSettingsDto {
+
+    private List<String> stadtbezirkNummer;
+
+    private List<String> kitaplanungsbereichKitaPlbT;
+
+    private List<Long> grundschulsprengelNummer;
+
+    private List<Long> mittelschulsprengelNummer;
+
+    private Integer realisierungsbeginnVon;
+
+    private Integer realisierungsbeginnBis;
+
+    private Boolean nurEigeneAbfragen;
+
+    private List<StatusAbfrage> statusAbfrage;
+
+    private UncertainBoolean sobonRelevant;
+
+    private Integer weGesamtVon;
+
+    private Integer weGesamtBis;
+
+    private BigDecimal gfWohnenGeplantVon;
+
+    private BigDecimal gfWohnenGeplantBis;
+
+    private List<Verfahrensstand> verfahrensstand;
+
+    private List<StatusInfrastruktureinrichtung> infrastruktureinrichtungStatus;
+}

--- a/src/main/java/de/muenchen/isi/api/dto/search/filter/FilterSettingsDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/search/filter/FilterSettingsDto.java
@@ -1,6 +1,7 @@
 package de.muenchen.isi.api.dto.search.filter;
 
 import de.muenchen.isi.api.validation.NotUnspecified;
+import de.muenchen.isi.domain.model.enums.SortAttribute;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusAbfrage;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusInfrastruktureinrichtung;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.UncertainBoolean;
@@ -11,11 +12,48 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.search.engine.search.sort.dsl.SortOrder;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class FilterSettingsDto {
+
+    @NotNull
+    private SortAttribute sortBy;
+
+    @NotNull
+    private SortOrder sortOrder;
+
+    @NotNull
+    private Boolean selectBauleitplanverfahren;
+
+    @NotNull
+    private Boolean selectBaugenehmigungsverfahren;
+
+    @NotNull
+    private Boolean selectWeiteresVerfahren;
+
+    @NotNull
+    private Boolean selectBauvorhaben;
+
+    @NotNull
+    private Boolean selectGrundschule;
+
+    @NotNull
+    private Boolean selectGsNachmittagBetreuung;
+
+    @NotNull
+    private Boolean selectHausFuerKinder;
+
+    @NotNull
+    private Boolean selectKindergarten;
+
+    @NotNull
+    private Boolean selectKinderkrippe;
+
+    @NotNull
+    private Boolean selectMittelschule;
 
     private List<String> stadtbezirkNummer;
 

--- a/src/main/java/de/muenchen/isi/api/dto/search/filter/FilterSettingsDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/search/filter/FilterSettingsDto.java
@@ -1,9 +1,11 @@
 package de.muenchen.isi.api.dto.search.filter;
 
+import de.muenchen.isi.api.validation.NotUnspecified;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusAbfrage;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusInfrastruktureinrichtung;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.UncertainBoolean;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.Verfahrensstand;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -31,6 +33,8 @@ public class FilterSettingsDto {
 
     private List<StatusAbfrage> statusAbfrage;
 
+    @NotNull
+    @NotUnspecified
     private UncertainBoolean sobonRelevant;
 
     private Integer weGesamtVon;

--- a/src/main/java/de/muenchen/isi/api/dto/search/filter/PersonalFilterRequestDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/search/filter/PersonalFilterRequestDto.java
@@ -13,8 +13,6 @@ public class PersonalFilterRequestDto {
 
     private UUID id;
 
-    private String personalID;
-
     @NotNull
     @Valid
     private FilterSettingsDto filterSettings;

--- a/src/main/java/de/muenchen/isi/api/dto/search/filter/PersonalFilterRequestDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/search/filter/PersonalFilterRequestDto.java
@@ -1,5 +1,8 @@
 package de.muenchen.isi.api.dto.search.filter;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,7 +15,10 @@ public class PersonalFilterRequestDto {
 
     private String personalID;
 
+    @NotNull
+    @Valid
     private FilterSettingsDto filterSettings;
 
+    @NotEmpty
     private String filterName;
 }

--- a/src/main/java/de/muenchen/isi/api/dto/search/filter/PersonalFilterRequestDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/search/filter/PersonalFilterRequestDto.java
@@ -1,0 +1,18 @@
+package de.muenchen.isi.api.dto.search.filter;
+
+import java.util.UUID;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class PersonalFilterRequestDto {
+
+    private UUID id;
+
+    private String personalID;
+
+    private FilterSettingsDto filterSettings;
+
+    private String filterName;
+}

--- a/src/main/java/de/muenchen/isi/api/dto/search/filter/PersonalFilterResponseDto.java
+++ b/src/main/java/de/muenchen/isi/api/dto/search/filter/PersonalFilterResponseDto.java
@@ -1,0 +1,14 @@
+package de.muenchen.isi.api.dto.search.filter;
+
+import de.muenchen.isi.api.dto.BaseEntityDto;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class PersonalFilterResponseDto extends BaseEntityDto {
+
+    private FilterSettingsDto filterSettings;
+
+    private String filterName;
+}

--- a/src/main/java/de/muenchen/isi/api/mapper/PersonalFilterApiMapper.java
+++ b/src/main/java/de/muenchen/isi/api/mapper/PersonalFilterApiMapper.java
@@ -7,6 +7,7 @@ import de.muenchen.isi.domain.model.search.filter.PersonalFilterRequestModel;
 import de.muenchen.isi.domain.model.search.filter.PersonalFilterResponseModel;
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(config = MapstructConfiguration.class)
 public interface PersonalFilterApiMapper {
@@ -14,5 +15,6 @@ public interface PersonalFilterApiMapper {
 
     List<PersonalFilterResponseDto> models2Dtos(final List<PersonalFilterResponseModel> personalFilterResponseModel);
 
+    @Mapping(target = "personalID", ignore = true)
     PersonalFilterRequestModel dto2Model(final PersonalFilterRequestDto personalFilterRequestDto);
 }

--- a/src/main/java/de/muenchen/isi/api/mapper/PersonalFilterApiMapper.java
+++ b/src/main/java/de/muenchen/isi/api/mapper/PersonalFilterApiMapper.java
@@ -1,0 +1,18 @@
+package de.muenchen.isi.api.mapper;
+
+import de.muenchen.isi.api.dto.search.filter.PersonalFilterRequestDto;
+import de.muenchen.isi.api.dto.search.filter.PersonalFilterResponseDto;
+import de.muenchen.isi.configuration.MapstructConfiguration;
+import de.muenchen.isi.domain.model.search.filter.PersonalFilterRequestModel;
+import de.muenchen.isi.domain.model.search.filter.PersonalFilterResponseModel;
+import java.util.List;
+import org.mapstruct.Mapper;
+
+@Mapper(config = MapstructConfiguration.class)
+public interface PersonalFilterApiMapper {
+    PersonalFilterResponseDto model2Dto(final PersonalFilterResponseModel personalFilterResponseModel);
+
+    List<PersonalFilterResponseDto> models2Dtos(final List<PersonalFilterResponseModel> personalFilterResponseModel);
+
+    PersonalFilterRequestModel dto2Model(final PersonalFilterRequestDto personalFilterRequestDto);
+}

--- a/src/main/java/de/muenchen/isi/domain/mapper/PersonalFilterDomainMapper.java
+++ b/src/main/java/de/muenchen/isi/domain/mapper/PersonalFilterDomainMapper.java
@@ -1,0 +1,21 @@
+package de.muenchen.isi.domain.mapper;
+
+import de.muenchen.isi.configuration.MapstructConfiguration;
+import de.muenchen.isi.domain.model.search.filter.PersonalFilterRequestModel;
+import de.muenchen.isi.domain.model.search.filter.PersonalFilterResponseModel;
+import de.muenchen.isi.infrastructure.entity.search.filter.PersonalFilter;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(config = MapstructConfiguration.class)
+public interface PersonalFilterDomainMapper {
+    PersonalFilterResponseModel entity2Model(final PersonalFilter personalFilter);
+
+    List<PersonalFilterResponseModel> entities2Models(final List<PersonalFilter> personalFilter);
+
+    @Mapping(target = "version", ignore = true)
+    @Mapping(target = "createdDateTime", ignore = true)
+    @Mapping(target = "lastModifiedDateTime", ignore = true)
+    PersonalFilter model2Entity(final PersonalFilterRequestModel personalFilterRequestModel);
+}

--- a/src/main/java/de/muenchen/isi/domain/mapper/PersonalFilterDomainMapper.java
+++ b/src/main/java/de/muenchen/isi/domain/mapper/PersonalFilterDomainMapper.java
@@ -7,6 +7,7 @@ import de.muenchen.isi.infrastructure.entity.search.filter.PersonalFilter;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 @Mapper(config = MapstructConfiguration.class)
 public interface PersonalFilterDomainMapper {
@@ -18,4 +19,9 @@ public interface PersonalFilterDomainMapper {
     @Mapping(target = "createdDateTime", ignore = true)
     @Mapping(target = "lastModifiedDateTime", ignore = true)
     PersonalFilter model2Entity(final PersonalFilterRequestModel personalFilterRequestModel);
+
+    @Mapping(target = "version", ignore = true)
+    @Mapping(target = "createdDateTime", ignore = true)
+    @Mapping(target = "lastModifiedDateTime", ignore = true)
+    void updateEntityFromModel(PersonalFilterRequestModel model, @MappingTarget PersonalFilter entity);
 }

--- a/src/main/java/de/muenchen/isi/domain/model/search/filter/FilterSettingsModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/search/filter/FilterSettingsModel.java
@@ -28,7 +28,6 @@ public class FilterSettingsModel {
 
     private List<StatusAbfrage> statusAbfrage;
 
-    @NotNull
     private UncertainBoolean sobonRelevant;
 
     private Integer weGesamtVon;

--- a/src/main/java/de/muenchen/isi/domain/model/search/filter/FilterSettingsModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/search/filter/FilterSettingsModel.java
@@ -1,16 +1,44 @@
 package de.muenchen.isi.domain.model.search.filter;
 
+import de.muenchen.isi.domain.model.enums.SortAttribute;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusAbfrage;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusInfrastruktureinrichtung;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.UncertainBoolean;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.Verfahrensstand;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.List;
 import lombok.Data;
+import org.hibernate.search.engine.search.sort.dsl.SortOrder;
 
 @Data
 public class FilterSettingsModel {
+
+    private SortAttribute sortBy;
+
+    private SortOrder sortOrder;
+
+    private Boolean selectBauleitplanverfahren;
+
+    private Boolean selectBaugenehmigungsverfahren;
+
+    private Boolean selectWeiteresVerfahren;
+
+    private Boolean selectBauvorhaben;
+
+    private Boolean selectGrundschule;
+
+    private Boolean selectGsNachmittagBetreuung;
+
+    private Boolean selectHausFuerKinder;
+
+    private Boolean selectKindergarten;
+
+    private Boolean selectKinderkrippe;
+
+    private Boolean selectMittelschule;
 
     private List<String> stadtbezirkNummer;
 

--- a/src/main/java/de/muenchen/isi/domain/model/search/filter/FilterSettingsModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/search/filter/FilterSettingsModel.java
@@ -1,0 +1,43 @@
+package de.muenchen.isi.domain.model.search.filter;
+
+import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusAbfrage;
+import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusInfrastruktureinrichtung;
+import de.muenchen.isi.infrastructure.entity.enums.lookup.UncertainBoolean;
+import de.muenchen.isi.infrastructure.entity.enums.lookup.Verfahrensstand;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class FilterSettingsModel {
+
+    private List<String> stadtbezirkNummer;
+
+    private List<String> kitaplanungsbereichKitaPlbT;
+
+    private List<Long> grundschulsprengelNummer;
+
+    private List<Long> mittelschulsprengelNummer;
+
+    private Integer realisierungsbeginnVon;
+
+    private Integer realisierungsbeginnBis;
+
+    private Boolean nurEigeneAbfragen;
+
+    private List<StatusAbfrage> statusAbfrage;
+
+    private UncertainBoolean sobonRelevant;
+
+    private Integer weGesamtVon;
+
+    private Integer weGesamtBis;
+
+    private BigDecimal gfWohnenGeplantVon;
+
+    private BigDecimal gfWohnenGeplantBis;
+
+    private List<Verfahrensstand> verfahrensstand;
+
+    private List<StatusInfrastruktureinrichtung> infrastruktureinrichtungStatus;
+}

--- a/src/main/java/de/muenchen/isi/domain/model/search/filter/FilterSettingsModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/search/filter/FilterSettingsModel.java
@@ -4,6 +4,7 @@ import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusAbfrage;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusInfrastruktureinrichtung;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.UncertainBoolean;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.Verfahrensstand;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.List;
 import lombok.Data;
@@ -27,6 +28,7 @@ public class FilterSettingsModel {
 
     private List<StatusAbfrage> statusAbfrage;
 
+    @NotNull
     private UncertainBoolean sobonRelevant;
 
     private Integer weGesamtVon;

--- a/src/main/java/de/muenchen/isi/domain/model/search/filter/PersonalFilterRequestModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/search/filter/PersonalFilterRequestModel.java
@@ -1,0 +1,16 @@
+package de.muenchen.isi.domain.model.search.filter;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class PersonalFilterRequestModel {
+
+    private UUID id;
+
+    private String personalID;
+
+    private String filterName;
+
+    private FilterSettingsModel filterSettings;
+}

--- a/src/main/java/de/muenchen/isi/domain/model/search/filter/PersonalFilterRequestModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/search/filter/PersonalFilterRequestModel.java
@@ -11,9 +11,7 @@ public class PersonalFilterRequestModel {
 
     private String personalID;
 
-    @NotNull
     private String filterName;
 
-    @NotNull
     private FilterSettingsModel filterSettings;
 }

--- a/src/main/java/de/muenchen/isi/domain/model/search/filter/PersonalFilterRequestModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/search/filter/PersonalFilterRequestModel.java
@@ -1,5 +1,6 @@
 package de.muenchen.isi.domain.model.search.filter;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.Data;
 
@@ -10,7 +11,9 @@ public class PersonalFilterRequestModel {
 
     private String personalID;
 
+    @NotNull
     private String filterName;
 
+    @NotNull
     private FilterSettingsModel filterSettings;
 }

--- a/src/main/java/de/muenchen/isi/domain/model/search/filter/PersonalFilterResponseModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/search/filter/PersonalFilterResponseModel.java
@@ -1,0 +1,16 @@
+package de.muenchen.isi.domain.model.search.filter;
+
+import de.muenchen.isi.domain.model.BaseEntityModel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class PersonalFilterResponseModel extends BaseEntityModel {
+
+    private String personalID;
+
+    private String filterName;
+
+    private FilterSettingsModel filterSettings;
+}

--- a/src/main/java/de/muenchen/isi/domain/model/search/filter/PersonalFilterResponseModel.java
+++ b/src/main/java/de/muenchen/isi/domain/model/search/filter/PersonalFilterResponseModel.java
@@ -8,8 +8,6 @@ import lombok.EqualsAndHashCode;
 @Data
 public class PersonalFilterResponseModel extends BaseEntityModel {
 
-    private String personalID;
-
     private String filterName;
 
     private FilterSettingsModel filterSettings;

--- a/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
@@ -25,17 +25,31 @@ public class PersonalFilterService {
 
     private final PersonalFilterRepository personalFilterRepository;
 
+    /**
+     * Gibt alle eigenen persönlichen Filter zurück.
+     *
+     * @return alle von diesem Nutzer existierenden persönlichen Filter als Liste (exklusive der userID)
+     * @throws IllegalAccessException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
+     */
     public List<PersonalFilterResponseModel> getPersonalFilters() throws IllegalAccessException {
         var entities = personalFilterRepository.findByPersonalID(getSubFromAuthenticatedUser());
         return personalFilterDomainMapper.entities2Models(entities);
     }
 
-    public PersonalFilterResponseModel getByFilterID(UUID filter_id)
+    /**
+     * Gibt einen spezifisch angefragten persönlichen Filter zurück.
+     *
+     * @param filterId des zu lesenden persönlichen Filters
+     * @return den persönlichen Filter mit dieser ID (exklusive der userID)
+     * @throws EntityNotFoundException falls es keinen persönlichen Filter mit dieser ID gibt
+     * @throws IllegalAccessException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
+     */
+    public PersonalFilterResponseModel getByFilterID(UUID filterId)
         throws EntityNotFoundException, IllegalAccessException {
         String userSub = getSubFromAuthenticatedUser();
-        var entity = personalFilterRepository.findByIdAndPersonalID(filter_id, userSub);
+        var entity = personalFilterRepository.findByIdAndPersonalID(filterId, userSub);
         if (entity == null) {
-            if (personalFilterRepository.findById(filter_id).isPresent()) {
+            if (personalFilterRepository.findById(filterId).isPresent()) {
                 throw new IllegalAccessException("Sie sind nicht der Ersteller dieses persönlichen Filters.");
             }
             throw new EntityNotFoundException("PersonalFilter nicht gefunden.");
@@ -43,6 +57,15 @@ public class PersonalFilterService {
         return personalFilterDomainMapper.entity2Model(entity);
     }
 
+    /**
+     * Aktualisiert einen spezifizierten persönlichen Filter.
+     *
+     * @param personalFilterRequestModel entspricht neuen persönlichen Filtereinstellungen, die bestehende Filtereinstellungen überschreiben sollen
+     * @return den aktualisierten persönlichen Filter (exklusive der userID)
+     * @throws EntityNotFoundException falls es keinen persönlichen Filter mit dieser ID gibt
+     * @throws OptimisticLockingException falls es bereits eine neuere Version der Entität in der Datenbank gibt
+     * @throws IllegalAccessException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
+     */
     public PersonalFilterResponseModel update(PersonalFilterRequestModel personalFilterRequestModel)
         throws EntityNotFoundException, OptimisticLockingException, IllegalAccessException {
         personalFilterRequestModel.setPersonalID(getSubFromAuthenticatedUser());
@@ -66,10 +89,18 @@ public class PersonalFilterService {
         return personalFilterDomainMapper.entity2Model(entity);
     }
 
+    /**
+     * Speichert einen persönlichen Filter und gibt diesen inkl. FilterId zurück.
+     *
+     * @param personalFilterRequestModel entspricht dem persönlichen Filter, der gespeichert werden soll
+     * @return den gespeicherten persönlichen Filter (exklusive der userID)
+     * @throws OptimisticLockingException falls es bereits eine neuere Version der Entität in der Datenbank gibt
+     * @throws IllegalAccessException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
+     */
     public PersonalFilterResponseModel save(PersonalFilterRequestModel personalFilterRequestModel)
         throws OptimisticLockingException, IllegalAccessException {
         personalFilterRequestModel.setPersonalID(getSubFromAuthenticatedUser());
-        if (authenticationUtils.isSubFromAuthenticatedUser(personalFilterRequestModel.getPersonalID())) {
+        if (authenticationUtils.isSubFromUnauthenticatedUser(personalFilterRequestModel.getPersonalID())) {
             throw new IllegalAccessException(
                 "Sie müssen authentifiziert sein, um mit persönlichen Filtern interagieren zu können"
             );
@@ -84,6 +115,13 @@ public class PersonalFilterService {
         return personalFilterDomainMapper.entity2Model(entity);
     }
 
+    /**
+     * Löscht einen spezifisch angegebenen Filter.
+     *
+     * @param filterId des zu löschenden persönlichen Filters
+     * @throws EntityNotFoundException falls es keinen persönlichen Filter mit dieser ID gibt
+     * @throws IllegalAccessException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
+     */
     public void delete(UUID filterId) throws EntityNotFoundException, IllegalAccessException {
         var verifyEntity = personalFilterRepository.findByIdAndPersonalID(filterId, getSubFromAuthenticatedUser());
         if (verifyEntity == null) {
@@ -95,9 +133,15 @@ public class PersonalFilterService {
         this.personalFilterRepository.deleteById(filterId);
     }
 
+    /**
+     * Gibt den userSub zurück sofern es kein Fallback-Wert ist.
+     *
+     * @return den userSub aus authenticationUtils
+     * @throws IllegalAccessException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
+     */
     private String getSubFromAuthenticatedUser() throws IllegalAccessException {
         final String userSub = authenticationUtils.getUserSub();
-        if (authenticationUtils.isSubFromAuthenticatedUser(userSub)) {
+        if (authenticationUtils.isSubFromUnauthenticatedUser(userSub)) {
             throw new IllegalAccessException(
                 "Sie müssen authentifiziert sein, um mit persönlichen Filtern interagieren zu können"
             );

--- a/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
@@ -75,7 +75,8 @@ public class PersonalFilterService {
             personalFilterRequestModel.getPersonalID()
         );
         if (entity == null) {
-            if (personalFilterRepository.findById(personalFilterRequestModel.getId()).isPresent()) {
+            UUID id = personalFilterRequestModel.getId();
+            if (id != null && personalFilterRepository.findById(id).isPresent()) {
                 throw new UserRoleNotAllowedException("Sie sind nicht der Ersteller dieses persönlichen Filters.");
             }
             throw new EntityNotFoundException("PersonalFilter nicht gefunden.");
@@ -100,6 +101,9 @@ public class PersonalFilterService {
      */
     public PersonalFilterResponseModel save(PersonalFilterRequestModel personalFilterRequestModel)
         throws OptimisticLockingException, UserRoleNotAllowedException {
+        if (personalFilterRequestModel.getId() != null) {
+            personalFilterRequestModel.setId(null);
+        }
         personalFilterRequestModel.setPersonalID(getSubFromAuthenticatedUser());
         var entity = personalFilterDomainMapper.model2Entity(personalFilterRequestModel);
         try {

--- a/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
@@ -2,6 +2,7 @@ package de.muenchen.isi.domain.service.search;
 
 import de.muenchen.isi.domain.exception.EntityNotFoundException;
 import de.muenchen.isi.domain.exception.OptimisticLockingException;
+import de.muenchen.isi.domain.exception.UserRoleNotAllowedException;
 import de.muenchen.isi.domain.mapper.PersonalFilterDomainMapper;
 import de.muenchen.isi.domain.model.search.filter.PersonalFilterRequestModel;
 import de.muenchen.isi.domain.model.search.filter.PersonalFilterResponseModel;
@@ -29,9 +30,9 @@ public class PersonalFilterService {
      * Gibt alle eigenen persönlichen Filter zurück.
      *
      * @return alle von diesem Nutzer existierenden persönlichen Filter als Liste (exklusive der userID)
-     * @throws IllegalAccessException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
+     * @throws UserRoleNotAllowedException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
      */
-    public List<PersonalFilterResponseModel> getPersonalFilters() throws IllegalAccessException {
+    public List<PersonalFilterResponseModel> getPersonalFilters() throws UserRoleNotAllowedException {
         var entities = personalFilterRepository.findByPersonalID(getSubFromAuthenticatedUser());
         return personalFilterDomainMapper.entities2Models(entities);
     }
@@ -42,15 +43,15 @@ public class PersonalFilterService {
      * @param filterId des zu lesenden persönlichen Filters
      * @return den persönlichen Filter mit dieser ID (exklusive der userID)
      * @throws EntityNotFoundException falls es keinen persönlichen Filter mit dieser ID gibt
-     * @throws IllegalAccessException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
+     * @throws UserRoleNotAllowedException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
      */
     public PersonalFilterResponseModel getByFilterID(UUID filterId)
-        throws EntityNotFoundException, IllegalAccessException {
+        throws EntityNotFoundException, UserRoleNotAllowedException {
         String userSub = getSubFromAuthenticatedUser();
         var entity = personalFilterRepository.findByIdAndPersonalID(filterId, userSub);
         if (entity == null) {
             if (personalFilterRepository.findById(filterId).isPresent()) {
-                throw new IllegalAccessException("Sie sind nicht der Ersteller dieses persönlichen Filters.");
+                throw new UserRoleNotAllowedException("Sie sind nicht der Ersteller dieses persönlichen Filters.");
             }
             throw new EntityNotFoundException("PersonalFilter nicht gefunden.");
         }
@@ -64,10 +65,10 @@ public class PersonalFilterService {
      * @return den aktualisierten persönlichen Filter (exklusive der userID)
      * @throws EntityNotFoundException falls es keinen persönlichen Filter mit dieser ID gibt
      * @throws OptimisticLockingException falls es bereits eine neuere Version der Entität in der Datenbank gibt
-     * @throws IllegalAccessException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
+     * @throws UserRoleNotAllowedException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
      */
     public PersonalFilterResponseModel update(PersonalFilterRequestModel personalFilterRequestModel)
-        throws EntityNotFoundException, OptimisticLockingException, IllegalAccessException {
+        throws EntityNotFoundException, OptimisticLockingException, UserRoleNotAllowedException {
         personalFilterRequestModel.setPersonalID(getSubFromAuthenticatedUser());
         var entity = personalFilterRepository.findByIdAndPersonalID(
             personalFilterRequestModel.getId(),
@@ -75,7 +76,7 @@ public class PersonalFilterService {
         );
         if (entity == null) {
             if (personalFilterRepository.findById(personalFilterRequestModel.getId()).isPresent()) {
-                throw new IllegalAccessException("Sie sind nicht der Ersteller dieses persönlichen Filters.");
+                throw new UserRoleNotAllowedException("Sie sind nicht der Ersteller dieses persönlichen Filters.");
             }
             throw new EntityNotFoundException("PersonalFilter nicht gefunden.");
         }
@@ -95,16 +96,11 @@ public class PersonalFilterService {
      * @param personalFilterRequestModel entspricht dem persönlichen Filter, der gespeichert werden soll
      * @return den gespeicherten persönlichen Filter (exklusive der userID)
      * @throws OptimisticLockingException falls es bereits eine neuere Version der Entität in der Datenbank gibt
-     * @throws IllegalAccessException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
+     * @throws UserRoleNotAllowedException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
      */
     public PersonalFilterResponseModel save(PersonalFilterRequestModel personalFilterRequestModel)
-        throws OptimisticLockingException, IllegalAccessException {
+        throws OptimisticLockingException, UserRoleNotAllowedException {
         personalFilterRequestModel.setPersonalID(getSubFromAuthenticatedUser());
-        if (authenticationUtils.isSubFromUnauthenticatedUser(personalFilterRequestModel.getPersonalID())) {
-            throw new IllegalAccessException(
-                "Sie müssen authentifiziert sein, um mit persönlichen Filtern interagieren zu können"
-            );
-        }
         var entity = personalFilterDomainMapper.model2Entity(personalFilterRequestModel);
         try {
             entity = this.personalFilterRepository.saveAndFlush(entity);
@@ -120,13 +116,13 @@ public class PersonalFilterService {
      *
      * @param filterId des zu löschenden persönlichen Filters
      * @throws EntityNotFoundException falls es keinen persönlichen Filter mit dieser ID gibt
-     * @throws IllegalAccessException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
+     * @throws UserRoleNotAllowedException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
      */
-    public void delete(UUID filterId) throws EntityNotFoundException, IllegalAccessException {
+    public void delete(UUID filterId) throws EntityNotFoundException, UserRoleNotAllowedException {
         var verifyEntity = personalFilterRepository.findByIdAndPersonalID(filterId, getSubFromAuthenticatedUser());
         if (verifyEntity == null) {
             if (personalFilterRepository.findById(filterId).isPresent()) {
-                throw new IllegalAccessException("Sie sind nicht der Ersteller dieses persönlichen Filters.");
+                throw new UserRoleNotAllowedException("Sie sind nicht der Ersteller dieses persönlichen Filters.");
             }
             throw new EntityNotFoundException("PersonalFilter nicht gefunden.");
         }
@@ -137,12 +133,12 @@ public class PersonalFilterService {
      * Gibt den userSub zurück sofern es kein Fallback-Wert ist.
      *
      * @return den userSub aus authenticationUtils
-     * @throws IllegalAccessException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
+     * @throws UserRoleNotAllowedException falls der Nutzer den Fallback-Sub aus AuthenticationUtils zugewiesen hat
      */
-    private String getSubFromAuthenticatedUser() throws IllegalAccessException {
+    private String getSubFromAuthenticatedUser() throws UserRoleNotAllowedException {
         final String userSub = authenticationUtils.getUserSub();
         if (authenticationUtils.isSubFromUnauthenticatedUser(userSub)) {
-            throw new IllegalAccessException(
+            throw new UserRoleNotAllowedException(
                 "Sie müssen authentifiziert sein, um mit persönlichen Filtern interagieren zu können"
             );
         }

--- a/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
@@ -1,0 +1,71 @@
+package de.muenchen.isi.domain.service.search;
+
+import de.muenchen.isi.domain.mapper.PersonalFilterDomainMapper;
+import de.muenchen.isi.domain.model.search.filter.PersonalFilterRequestModel;
+import de.muenchen.isi.domain.model.search.filter.PersonalFilterResponseModel;
+import de.muenchen.isi.infrastructure.repository.search.PersonalFilterRepository;
+import de.muenchen.isi.security.AuthenticationUtils;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PersonalFilterService {
+
+    private final PersonalFilterDomainMapper personalFilterDomainMapper;
+
+    private final AuthenticationUtils authenticationUtils;
+
+    private final PersonalFilterRepository personalFilterRepository;
+
+    public List<PersonalFilterResponseModel> getPersonalFilters() {
+        String userSub = authenticationUtils.getUserSub();
+        var entities = personalFilterRepository.findByPersonalID(userSub);
+        return personalFilterDomainMapper.entities2Models(entities);
+    }
+
+    public PersonalFilterResponseModel getByFilterID(PersonalFilterRequestModel personalFilterRequestModel) {
+        String userSub = authenticationUtils.getUserSub();
+        var entity = personalFilterRepository.findByIdAndPersonalID(personalFilterRequestModel.getId(), userSub);
+        return personalFilterDomainMapper.entity2Model(entity);
+    }
+
+    public PersonalFilterResponseModel update(PersonalFilterRequestModel personalFilterRequestModel) {
+        personalFilterRequestModel.setPersonalID(authenticationUtils.getUserSub());
+        var verifyEntity = personalFilterRepository.findByIdAndPersonalID(
+            personalFilterRequestModel.getId(),
+            personalFilterRequestModel.getPersonalID()
+        );
+        if (verifyEntity == null) {
+            return null;
+        }
+        var entity = personalFilterDomainMapper.model2Entity(personalFilterRequestModel);
+        entity.setVersion(verifyEntity.getVersion());
+        entity.setCreatedDateTime(verifyEntity.getCreatedDateTime());
+        entity.setLastModifiedDateTime(verifyEntity.getLastModifiedDateTime());
+        entity = personalFilterRepository.saveAndFlush(entity);
+        return personalFilterDomainMapper.entity2Model(entity);
+    }
+
+    public PersonalFilterResponseModel save(PersonalFilterRequestModel personalFilterRequestModel) {
+        personalFilterRequestModel.setPersonalID(authenticationUtils.getUserSub());
+        var entity = personalFilterDomainMapper.model2Entity(personalFilterRequestModel);
+        entity = this.personalFilterRepository.saveAndFlush(entity);
+        return personalFilterDomainMapper.entity2Model(entity);
+    }
+
+    public void delete(PersonalFilterRequestModel personalFilterRequestModel) {
+        personalFilterRequestModel.setPersonalID(authenticationUtils.getUserSub());
+        var verifyEntity = personalFilterRepository.findByIdAndPersonalID(
+            personalFilterRequestModel.getId(),
+            personalFilterRequestModel.getPersonalID()
+        );
+        if (verifyEntity == null) {
+            return;
+        }
+        this.personalFilterRepository.deleteById(personalFilterRequestModel.getId());
+    }
+}

--- a/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
@@ -6,6 +6,7 @@ import de.muenchen.isi.domain.model.search.filter.PersonalFilterResponseModel;
 import de.muenchen.isi.infrastructure.repository.search.PersonalFilterRepository;
 import de.muenchen.isi.security.AuthenticationUtils;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,9 +28,9 @@ public class PersonalFilterService {
         return personalFilterDomainMapper.entities2Models(entities);
     }
 
-    public PersonalFilterResponseModel getByFilterID(PersonalFilterRequestModel personalFilterRequestModel) {
+    public PersonalFilterResponseModel getByFilterID(UUID filter_id) {
         String userSub = authenticationUtils.getUserSub();
-        var entity = personalFilterRepository.findByIdAndPersonalID(personalFilterRequestModel.getId(), userSub);
+        var entity = personalFilterRepository.findByIdAndPersonalID(filter_id, userSub);
         return personalFilterDomainMapper.entity2Model(entity);
     }
 

--- a/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
@@ -25,15 +25,14 @@ public class PersonalFilterService {
 
     private final PersonalFilterRepository personalFilterRepository;
 
-    public List<PersonalFilterResponseModel> getPersonalFilters() {
-        String userSub = authenticationUtils.getUserSub();
-        var entities = personalFilterRepository.findByPersonalID(userSub);
+    public List<PersonalFilterResponseModel> getPersonalFilters() throws IllegalAccessException {
+        var entities = personalFilterRepository.findByPersonalID(getSubFromAuthenticatedUser());
         return personalFilterDomainMapper.entities2Models(entities);
     }
 
     public PersonalFilterResponseModel getByFilterID(UUID filter_id)
         throws EntityNotFoundException, IllegalAccessException {
-        String userSub = authenticationUtils.getUserSub();
+        String userSub = getSubFromAuthenticatedUser();
         var entity = personalFilterRepository.findByIdAndPersonalID(filter_id, userSub);
         if (entity == null) {
             if (personalFilterRepository.findById(filter_id).isPresent()) {
@@ -46,7 +45,7 @@ public class PersonalFilterService {
 
     public PersonalFilterResponseModel update(PersonalFilterRequestModel personalFilterRequestModel)
         throws EntityNotFoundException, OptimisticLockingException, IllegalAccessException {
-        personalFilterRequestModel.setPersonalID(authenticationUtils.getUserSub());
+        personalFilterRequestModel.setPersonalID(getSubFromAuthenticatedUser());
         var entity = personalFilterRepository.findByIdAndPersonalID(
             personalFilterRequestModel.getId(),
             personalFilterRequestModel.getPersonalID()
@@ -68,8 +67,13 @@ public class PersonalFilterService {
     }
 
     public PersonalFilterResponseModel save(PersonalFilterRequestModel personalFilterRequestModel)
-        throws OptimisticLockingException {
-        personalFilterRequestModel.setPersonalID(authenticationUtils.getUserSub());
+        throws OptimisticLockingException, IllegalAccessException {
+        personalFilterRequestModel.setPersonalID(getSubFromAuthenticatedUser());
+        if (authenticationUtils.isSubFromAuthenticatedUser(personalFilterRequestModel.getPersonalID())) {
+            throw new IllegalAccessException(
+                "Sie müssen authentifiziert sein, um mit persönlichen Filtern interagieren zu können"
+            );
+        }
         var entity = personalFilterDomainMapper.model2Entity(personalFilterRequestModel);
         try {
             entity = this.personalFilterRepository.saveAndFlush(entity);
@@ -81,7 +85,7 @@ public class PersonalFilterService {
     }
 
     public void delete(UUID filterId) throws EntityNotFoundException, IllegalAccessException {
-        var verifyEntity = personalFilterRepository.findByIdAndPersonalID(filterId, authenticationUtils.getUserSub());
+        var verifyEntity = personalFilterRepository.findByIdAndPersonalID(filterId, getSubFromAuthenticatedUser());
         if (verifyEntity == null) {
             if (personalFilterRepository.findById(filterId).isPresent()) {
                 throw new IllegalAccessException("Sie sind nicht der Ersteller dieses persönlichen Filters.");
@@ -89,5 +93,15 @@ public class PersonalFilterService {
             throw new EntityNotFoundException("PersonalFilter nicht gefunden.");
         }
         this.personalFilterRepository.deleteById(filterId);
+    }
+
+    private String getSubFromAuthenticatedUser() throws IllegalAccessException {
+        final String userSub = authenticationUtils.getUserSub();
+        if (authenticationUtils.isSubFromAuthenticatedUser(userSub)) {
+            throw new IllegalAccessException(
+                "Sie müssen authentifiziert sein, um mit persönlichen Filtern interagieren zu können"
+            );
+        }
+        return userSub;
     }
 }

--- a/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
@@ -1,5 +1,7 @@
 package de.muenchen.isi.domain.service.search;
 
+import de.muenchen.isi.domain.exception.EntityNotFoundException;
+import de.muenchen.isi.domain.exception.OptimisticLockingException;
 import de.muenchen.isi.domain.mapper.PersonalFilterDomainMapper;
 import de.muenchen.isi.domain.model.search.filter.PersonalFilterRequestModel;
 import de.muenchen.isi.domain.model.search.filter.PersonalFilterResponseModel;
@@ -9,6 +11,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -28,37 +31,62 @@ public class PersonalFilterService {
         return personalFilterDomainMapper.entities2Models(entities);
     }
 
-    public PersonalFilterResponseModel getByFilterID(UUID filter_id) {
+    public PersonalFilterResponseModel getByFilterID(UUID filter_id)
+        throws EntityNotFoundException, IllegalAccessException {
         String userSub = authenticationUtils.getUserSub();
         var entity = personalFilterRepository.findByIdAndPersonalID(filter_id, userSub);
+        if (entity == null) {
+            if (personalFilterRepository.findById(filter_id).isPresent()) {
+                throw new IllegalAccessException("Sie sind nicht der Ersteller dieses persönlichen Filters.");
+            }
+            throw new EntityNotFoundException("PersonalFilter nicht gefunden.");
+        }
         return personalFilterDomainMapper.entity2Model(entity);
     }
 
-    public PersonalFilterResponseModel update(PersonalFilterRequestModel personalFilterRequestModel) {
+    public PersonalFilterResponseModel update(PersonalFilterRequestModel personalFilterRequestModel)
+        throws EntityNotFoundException, OptimisticLockingException, IllegalAccessException {
         personalFilterRequestModel.setPersonalID(authenticationUtils.getUserSub());
         var entity = personalFilterRepository.findByIdAndPersonalID(
             personalFilterRequestModel.getId(),
             personalFilterRequestModel.getPersonalID()
         );
         if (entity == null) {
-            return null;
+            if (personalFilterRepository.findById(personalFilterRequestModel.getId()).isPresent()) {
+                throw new IllegalAccessException("Sie sind nicht der Ersteller dieses persönlichen Filters.");
+            }
+            throw new EntityNotFoundException("PersonalFilter nicht gefunden.");
         }
         personalFilterDomainMapper.updateEntityFromModel(personalFilterRequestModel, entity);
-        entity = personalFilterRepository.saveAndFlush(entity);
+        try {
+            entity = personalFilterRepository.saveAndFlush(entity);
+        } catch (final ObjectOptimisticLockingFailureException exception) {
+            final var message = "Die Daten wurden in der Zwischenzeit geändert. Bitte laden Sie die Seite neu!";
+            throw new OptimisticLockingException(message, exception);
+        }
         return personalFilterDomainMapper.entity2Model(entity);
     }
 
-    public PersonalFilterResponseModel save(PersonalFilterRequestModel personalFilterRequestModel) {
+    public PersonalFilterResponseModel save(PersonalFilterRequestModel personalFilterRequestModel)
+        throws OptimisticLockingException {
         personalFilterRequestModel.setPersonalID(authenticationUtils.getUserSub());
         var entity = personalFilterDomainMapper.model2Entity(personalFilterRequestModel);
-        entity = this.personalFilterRepository.saveAndFlush(entity);
+        try {
+            entity = this.personalFilterRepository.saveAndFlush(entity);
+        } catch (final ObjectOptimisticLockingFailureException exception) {
+            final var message = "Die Daten wurden in der Zwischenzeit geändert. Bitte laden Sie die Seite neu!";
+            throw new OptimisticLockingException(message, exception);
+        }
         return personalFilterDomainMapper.entity2Model(entity);
     }
 
-    public void delete(UUID filterId) {
+    public void delete(UUID filterId) throws EntityNotFoundException, IllegalAccessException {
         var verifyEntity = personalFilterRepository.findByIdAndPersonalID(filterId, authenticationUtils.getUserSub());
         if (verifyEntity == null) {
-            return;
+            if (personalFilterRepository.findById(filterId).isPresent()) {
+                throw new IllegalAccessException("Sie sind nicht der Ersteller dieses persönlichen Filters.");
+            }
+            throw new EntityNotFoundException("PersonalFilter nicht gefunden.");
         }
         this.personalFilterRepository.deleteById(filterId);
     }

--- a/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
@@ -36,17 +36,14 @@ public class PersonalFilterService {
 
     public PersonalFilterResponseModel update(PersonalFilterRequestModel personalFilterRequestModel) {
         personalFilterRequestModel.setPersonalID(authenticationUtils.getUserSub());
-        var verifyEntity = personalFilterRepository.findByIdAndPersonalID(
+        var entity = personalFilterRepository.findByIdAndPersonalID(
             personalFilterRequestModel.getId(),
             personalFilterRequestModel.getPersonalID()
         );
-        if (verifyEntity == null) {
+        if (entity == null) {
             return null;
         }
-        var entity = personalFilterDomainMapper.model2Entity(personalFilterRequestModel);
-        entity.setVersion(verifyEntity.getVersion());
-        entity.setCreatedDateTime(verifyEntity.getCreatedDateTime());
-        entity.setLastModifiedDateTime(verifyEntity.getLastModifiedDateTime());
+        personalFilterDomainMapper.updateEntityFromModel(personalFilterRequestModel, entity);
         entity = personalFilterRepository.saveAndFlush(entity);
         return personalFilterDomainMapper.entity2Model(entity);
     }

--- a/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
+++ b/src/main/java/de/muenchen/isi/domain/service/search/PersonalFilterService.java
@@ -55,15 +55,11 @@ public class PersonalFilterService {
         return personalFilterDomainMapper.entity2Model(entity);
     }
 
-    public void delete(PersonalFilterRequestModel personalFilterRequestModel) {
-        personalFilterRequestModel.setPersonalID(authenticationUtils.getUserSub());
-        var verifyEntity = personalFilterRepository.findByIdAndPersonalID(
-            personalFilterRequestModel.getId(),
-            personalFilterRequestModel.getPersonalID()
-        );
+    public void delete(UUID filterId) {
+        var verifyEntity = personalFilterRepository.findByIdAndPersonalID(filterId, authenticationUtils.getUserSub());
         if (verifyEntity == null) {
             return;
         }
-        this.personalFilterRepository.deleteById(personalFilterRequestModel.getId());
+        this.personalFilterRepository.deleteById(filterId);
     }
 }

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/FilterSettings.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/FilterSettings.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Index;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.List;
 import lombok.Data;
@@ -63,6 +64,7 @@ public class FilterSettings {
     )
     private List<StatusAbfrage> statusAbfrage;
 
+    @NotNull
     @GenericField(name = "sobon_relevant_filter")
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(255) not null check (sobon_relevant != 'UNSPECIFIED')")

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/FilterSettings.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/FilterSettings.java
@@ -5,11 +5,15 @@ import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusInfrastrukturein
 import de.muenchen.isi.infrastructure.entity.enums.lookup.UncertainBoolean;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.Verfahrensstand;
 import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Index;
 import java.math.BigDecimal;
 import java.util.List;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 
 @Embeddable
 public class FilterSettings {
@@ -51,11 +55,15 @@ public class FilterSettings {
     private Boolean nurEigeneAbfragen;
 
     @ElementCollection
+    @Enumerated(EnumType.STRING)
     @CollectionTable(
         indexes = { @Index(name = "personal_filter_status_abfrage_id_idx", columnList = "personal_filter_id") }
     )
     private List<StatusAbfrage> statusAbfrage;
 
+    @GenericField(name = "sobon_relevant_filter")
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(255) not null check (sobon_relevant != 'UNSPECIFIED')")
     private UncertainBoolean sobonRelevant;
 
     private Integer weGesamtVon;
@@ -67,12 +75,14 @@ public class FilterSettings {
     private BigDecimal gfWohnenGeplantBis;
 
     @ElementCollection
+    @Enumerated(EnumType.STRING)
     @CollectionTable(
         indexes = { @Index(name = "personal_filter_verfahrensstand_id_idx", columnList = "personal_filter_id") }
     )
     private List<Verfahrensstand> verfahrensstand;
 
     @ElementCollection
+    @Enumerated(EnumType.STRING)
     @CollectionTable(
         indexes = {
             @Index(name = "personal_filter_infrastruktureinrichtung_status_id_idx", columnList = "personal_filter_id"),

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/FilterSettings.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/FilterSettings.java
@@ -1,0 +1,82 @@
+package de.muenchen.isi.infrastructure.entity.search.filter;
+
+import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusAbfrage;
+import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusInfrastruktureinrichtung;
+import de.muenchen.isi.infrastructure.entity.enums.lookup.UncertainBoolean;
+import de.muenchen.isi.infrastructure.entity.enums.lookup.Verfahrensstand;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Index;
+import java.math.BigDecimal;
+import java.util.List;
+
+@Embeddable
+public class FilterSettings {
+
+    @ElementCollection
+    @CollectionTable(
+        indexes = { @Index(name = "personal_filter_stadtbezirk_nummer_id_idx", columnList = "personal_filter_id") }
+    )
+    private List<String> stadtbezirkNummer;
+
+    @ElementCollection
+    @CollectionTable(
+        indexes = {
+            @Index(name = "personal_filter_kitaplanungsbereich_kita_plb_t_id_idx", columnList = "personal_filter_id"),
+        }
+    )
+    private List<String> kitaplanungsbereichKitaPlbT;
+
+    @ElementCollection
+    @CollectionTable(
+        indexes = {
+            @Index(name = "personal_filter_grundschulsprengel_nummer_id_idx", columnList = "personal_filter_id"),
+        }
+    )
+    private List<Long> grundschulsprengelNummer;
+
+    @ElementCollection
+    @CollectionTable(
+        indexes = {
+            @Index(name = "personal_filter_mittelschulsprengel_nummer_id_idx", columnList = "personal_filter_id"),
+        }
+    )
+    private List<Long> mittelschulsprengelNummer;
+
+    private Integer realisierungsbeginnVon;
+
+    private Integer realisierungsbeginnBis;
+
+    private Boolean nurEigeneAbfragen;
+
+    @ElementCollection
+    @CollectionTable(
+        indexes = { @Index(name = "personal_filter_status_abfrage_id_idx", columnList = "personal_filter_id") }
+    )
+    private List<StatusAbfrage> statusAbfrage;
+
+    private UncertainBoolean sobonRelevant;
+
+    private Integer weGesamtVon;
+
+    private Integer weGesamtBis;
+
+    private BigDecimal gfWohnenGeplantVon;
+
+    private BigDecimal gfWohnenGeplantBis;
+
+    @ElementCollection
+    @CollectionTable(
+        indexes = { @Index(name = "personal_filter_verfahrensstand_id_idx", columnList = "personal_filter_id") }
+    )
+    private List<Verfahrensstand> verfahrensstand;
+
+    @ElementCollection
+    @CollectionTable(
+        indexes = {
+            @Index(name = "personal_filter_infrastruktureinrichtung_status_id_idx", columnList = "personal_filter_id"),
+        }
+    )
+    private List<StatusInfrastruktureinrichtung> infrastruktureinrichtungStatus;
+}

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/FilterSettings.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/FilterSettings.java
@@ -1,5 +1,6 @@
 package de.muenchen.isi.infrastructure.entity.search.filter;
 
+import de.muenchen.isi.domain.model.enums.SortAttribute;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusAbfrage;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.StatusInfrastruktureinrichtung;
 import de.muenchen.isi.infrastructure.entity.enums.lookup.UncertainBoolean;
@@ -15,11 +16,50 @@ import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.List;
 import lombok.Data;
+import org.hibernate.search.engine.search.sort.dsl.SortOrder;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 
 @Embeddable
 @Data
 public class FilterSettings {
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private SortAttribute sortBy;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private SortOrder sortOrder;
+
+    @NotNull
+    private Boolean selectBauleitplanverfahren;
+
+    @NotNull
+    private Boolean selectBaugenehmigungsverfahren;
+
+    @NotNull
+    private Boolean selectWeiteresVerfahren;
+
+    @NotNull
+    private Boolean selectBauvorhaben;
+
+    @NotNull
+    private Boolean selectGrundschule;
+
+    @NotNull
+    private Boolean selectGsNachmittagBetreuung;
+
+    @NotNull
+    private Boolean selectHausFuerKinder;
+
+    @NotNull
+    private Boolean selectKindergarten;
+
+    @NotNull
+    private Boolean selectKinderkrippe;
+
+    @NotNull
+    private Boolean selectMittelschule;
 
     @ElementCollection
     @CollectionTable(

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/FilterSettings.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/FilterSettings.java
@@ -13,9 +13,11 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Index;
 import java.math.BigDecimal;
 import java.util.List;
+import lombok.Data;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 
 @Embeddable
+@Data
 public class FilterSettings {
 
     @ElementCollection

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/PersonalFilter.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/PersonalFilter.java
@@ -22,9 +22,7 @@ import org.hibernate.type.SqlTypes;
 @EqualsAndHashCode(callSuper = true)
 public class PersonalFilter extends BaseEntity {
 
-    @Column(length = 36)
-    @JdbcTypeCode(SqlTypes.VARCHAR)
-    private UUID personalID;
+    private String personalID;
 
     private String filterName;
 

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/PersonalFilter.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/PersonalFilter.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -22,6 +23,7 @@ public class PersonalFilter extends BaseEntity {
 
     private String filterName;
 
+    @NotNull
     @Embedded
     private FilterSettings filterSettings;
 }

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/PersonalFilter.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/PersonalFilter.java
@@ -1,0 +1,32 @@
+package de.muenchen.isi.infrastructure.entity.search.filter;
+
+import de.muenchen.isi.infrastructure.entity.BaseEntity;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import java.util.UUID;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+
+@Entity
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@DiscriminatorColumn(name = "personalFilterSettings")
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class PersonalFilter extends BaseEntity {
+
+    @Id
+    private UUID filterID;
+
+    private UUID personalID;
+
+    private String filterName;
+
+    @Embedded
+    private FilterSettings filterSettings;
+}

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/PersonalFilter.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/PersonalFilter.java
@@ -1,18 +1,14 @@
 package de.muenchen.isi.infrastructure.entity.search.filter;
 
 import de.muenchen.isi.infrastructure.entity.BaseEntity;
-import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
-import java.util.UUID;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 @Entity
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/PersonalFilter.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/PersonalFilter.java
@@ -6,6 +6,8 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -19,10 +21,13 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 public class PersonalFilter extends BaseEntity {
 
+    @NotEmpty
     private String personalID;
 
+    @NotEmpty
     private String filterName;
 
+    @Valid
     @NotNull
     @Embedded
     private FilterSettings filterSettings;

--- a/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/PersonalFilter.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/entity/search/filter/PersonalFilter.java
@@ -1,6 +1,7 @@
 package de.muenchen.isi.infrastructure.entity.search.filter;
 
 import de.muenchen.isi.infrastructure.entity.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -10,7 +11,8 @@ import java.util.UUID;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.springframework.data.annotation.Id;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
@@ -20,9 +22,8 @@ import org.springframework.data.annotation.Id;
 @EqualsAndHashCode(callSuper = true)
 public class PersonalFilter extends BaseEntity {
 
-    @Id
-    private UUID filterID;
-
+    @Column(length = 36)
+    @JdbcTypeCode(SqlTypes.VARCHAR)
     private UUID personalID;
 
     private String filterName;

--- a/src/main/java/de/muenchen/isi/infrastructure/repository/search/PersonalFilterRepository.java
+++ b/src/main/java/de/muenchen/isi/infrastructure/repository/search/PersonalFilterRepository.java
@@ -1,0 +1,12 @@
+package de.muenchen.isi.infrastructure.repository.search;
+
+import de.muenchen.isi.infrastructure.entity.search.filter.PersonalFilter;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PersonalFilterRepository extends JpaRepository<PersonalFilter, UUID> {
+    List<PersonalFilter> findByPersonalID(String personalid);
+
+    PersonalFilter findByIdAndPersonalID(UUID id, String personalid);
+}

--- a/src/main/java/de/muenchen/isi/security/AuthenticationUtils.java
+++ b/src/main/java/de/muenchen/isi/security/AuthenticationUtils.java
@@ -161,6 +161,10 @@ public class AuthenticationUtils {
         return StringUtils.isNotBlank(sub) ? sub : SUB_UNAUTHENTICATED_USER;
     }
 
+    public boolean isSubFromUnauthenticatedUser(final String sub) {
+        return sub.equals(SUB_UNAUTHENTICATED_USER);
+    }
+
     /**
      * Die Methode extrahiert die Nutzerrollen des Nutzers aus dem {@link Jwt} der {@link Authentication} des {@link SecurityContextHolder}.
      *

--- a/src/main/java/de/muenchen/isi/security/AuthenticationUtils.java
+++ b/src/main/java/de/muenchen/isi/security/AuthenticationUtils.java
@@ -161,6 +161,12 @@ public class AuthenticationUtils {
         return StringUtils.isNotBlank(sub) ? sub : SUB_UNAUTHENTICATED_USER;
     }
 
+    /**
+     * Überprüft ob es sich um den Fallback-Sub Wert handelt, siehe getUserSub.
+     *
+     * @param sub entspricht dem zu überprüfenden String
+     * @return ob der sub dem Fallback-Wert entspricht
+     */
     public boolean isSubFromUnauthenticatedUser(final String sub) {
         return sub.equals(SUB_UNAUTHENTICATED_USER);
     }

--- a/src/main/resources/db/migration/V39__ISI2-833_Persoenliche_Filter.sql
+++ b/src/main/resources/db/migration/V39__ISI2-833_Persoenliche_Filter.sql
@@ -1,0 +1,83 @@
+BEGIN;
+
+--
+-- Persönliche Filter
+--
+
+CREATE TABLE isidbuser.personal_filter
+(
+    id                      character varying(36) PRIMARY KEY,
+    version                 BIGINT,
+    created_date_time       TIMESTAMP              NOT NULL,
+    last_modified_date_time TIMESTAMP              NOT NULL,
+
+    personalid              character varying(36)  NOT NULL,
+    filter_name             character varying(255) NOT NULL,
+
+    -- Embedded FilterSettings
+    realisierungsbeginn_von INTEGER,
+    realisierungsbeginn_bis INTEGER,
+    nur_eigene_abfragen     BOOLEAN,
+    sobon_relevant          character varying(255) NOT NULL,
+    we_gesamt_von           INTEGER,
+    we_gesamt_bis           INTEGER,
+    gf_wohnen_geplant_von   DECIMAL(19, 2),
+    gf_wohnen_geplant_bis   DECIMAL(19, 2)
+);
+
+CREATE TABLE isidbuser.personal_filter_stadtbezirk_nummer
+(
+    personal_filter_id character varying(36)  NOT NULL,
+    stadtbezirk_nummer character varying(255) NOT NULL,
+    FOREIGN KEY (personal_filter_id) REFERENCES personal_filter (id)
+);
+
+CREATE TABLE isidbuser.personal_filter_kitaplanungsbereich_kita_plbt
+(
+    personal_filter_id            character varying(36)  NOT NULL,
+    kitaplanungsbereich_kita_plbt character varying(255) NOT NULL,
+    FOREIGN KEY (personal_filter_id) REFERENCES personal_filter (id)
+);
+
+CREATE TABLE isidbuser.personal_filter_grundschulsprengel_nummer
+(
+    personal_filter_id        character varying(36) NOT NULL,
+    grundschulsprengel_nummer BIGINT                NOT NULL,
+    FOREIGN KEY (personal_filter_id) REFERENCES personal_filter (id)
+);
+
+CREATE TABLE isidbuser.personal_filter_mittelschulsprengel_nummer
+(
+    personal_filter_id         character varying(36) NOT NULL,
+    mittelschulsprengel_nummer BIGINT                NOT NULL,
+    FOREIGN KEY (personal_filter_id) REFERENCES personal_filter (id)
+);
+
+CREATE TABLE isidbuser.personal_filter_status_abfrage
+(
+    personal_filter_id character varying(36)  NOT NULL,
+    status_abfrage     character varying(255) NOT NULL,
+    FOREIGN KEY (personal_filter_id) REFERENCES personal_filter (id)
+);
+
+CREATE TABLE isidbuser.personal_filter_verfahrensstand
+(
+    personal_filter_id character varying(36)  NOT NULL,
+    verfahrensstand    character varying(255) NOT NULL,
+    FOREIGN KEY (personal_filter_id) REFERENCES personal_filter (id)
+);
+
+CREATE TABLE isidbuser.personal_filter_infrastruktureinrichtung_status
+(
+    personal_filter_id              character varying(36)  NOT NULL,
+    infrastruktureinrichtung_status character varying(255) NOT NULL,
+    FOREIGN KEY (personal_filter_id) REFERENCES personal_filter (id)
+);
+
+CREATE INDEX personal_filter_stadtbezirk_nummer_id_idx ON isidbuser.personal_filter_stadtbezirk_nummer (personal_filter_id);
+CREATE INDEX personal_filter_kitaplanungsbereich_kita_plbt_id_idx ON isidbuser.personal_filter_kitaplanungsbereich_kita_plbt (personal_filter_id);
+CREATE INDEX personal_filter_grundschulsprengel_nummer_id_idx ON isidbuser.personal_filter_grundschulsprengel_nummer (personal_filter_id);
+CREATE INDEX personal_filter_mittelschulsprengel_nummer_id_idx ON isidbuser.personal_filter_mittelschulsprengel_nummer (personal_filter_id);
+CREATE INDEX personal_filter_status_abfrage_id_idx ON isidbuser.personal_filter_status_abfrage (personal_filter_id);
+CREATE INDEX personal_filter_verfahrensstand_id_idx ON isidbuser.personal_filter_verfahrensstand (personal_filter_id);
+CREATE INDEX personal_filter_infrastruktureinrichtung_status_id_idx ON isidbuser.personal_filter_infrastruktureinrichtung_status (personal_filter_id);

--- a/src/main/resources/db/migration/V39__ISI2-833_Persoenliche_Filter.sql
+++ b/src/main/resources/db/migration/V39__ISI2-833_Persoenliche_Filter.sql
@@ -22,7 +22,8 @@ CREATE TABLE isidbuser.personal_filter
     we_gesamt_von           INTEGER,
     we_gesamt_bis           INTEGER,
     gf_wohnen_geplant_von   DECIMAL(19, 2),
-    gf_wohnen_geplant_bis   DECIMAL(19, 2)
+    gf_wohnen_geplant_bis   DECIMAL(19, 2),
+    CONSTRAINT personal_filter_sobon_relevant_check CHECK (((sobon_relevant)::text <> 'UNSPECIFIED'::text))
 );
 
 CREATE TABLE isidbuser.personal_filter_stadtbezirk_nummer

--- a/src/main/resources/db/migration/V39__ISI2-833_Persoenliche_Filter.sql
+++ b/src/main/resources/db/migration/V39__ISI2-833_Persoenliche_Filter.sql
@@ -6,23 +6,35 @@ BEGIN;
 
 CREATE TABLE isidbuser.personal_filter
 (
-    id                      character varying(36) PRIMARY KEY,
-    version                 BIGINT,
-    created_date_time       TIMESTAMP              NOT NULL,
-    last_modified_date_time TIMESTAMP              NOT NULL,
+    id                              character varying(36) PRIMARY KEY,
+    version                         BIGINT,
+    created_date_time               TIMESTAMP              NOT NULL,
+    last_modified_date_time         TIMESTAMP              NOT NULL,
 
-    personalid              character varying(255) NOT NULL,
-    filter_name             character varying(255) NOT NULL,
+    personalid                      character varying(255) NOT NULL,
+    filter_name                     character varying(255) NOT NULL,
 
     -- Embedded FilterSettings
-    realisierungsbeginn_von INTEGER,
-    realisierungsbeginn_bis INTEGER,
-    nur_eigene_abfragen     BOOLEAN,
-    sobon_relevant          character varying(255) NOT NULL,
-    we_gesamt_von           INTEGER,
-    we_gesamt_bis           INTEGER,
-    gf_wohnen_geplant_von   DECIMAL(19, 2),
-    gf_wohnen_geplant_bis   DECIMAL(19, 2),
+    sort_by                         character varying(255) NOT NULL,
+    sort_order                      character varying(255) NOT NULL,
+    select_bauleitplanverfahren     BOOLEAN                NOT NULL,
+    select_baugenehmigungsverfahren BOOLEAN                NOT NULL,
+    select_weiteres_verfahren       BOOLEAN                NOT NULL,
+    select_bauvorhaben              BOOLEAN                NOT NULL,
+    select_grundschule              BOOLEAN                NOT NULL,
+    select_gs_nachmittag_betreuung  BOOLEAN                NOT NULL,
+    select_haus_fuer_kinder         BOOLEAN                NOT NULL,
+    select_kindergarten             BOOLEAN                NOT NULL,
+    select_kinderkrippe             BOOLEAN                NOT NULL,
+    select_mittelschule             BOOLEAN                NOT NULL,
+    realisierungsbeginn_von         INTEGER,
+    realisierungsbeginn_bis         INTEGER,
+    nur_eigene_abfragen             BOOLEAN,
+    sobon_relevant                  character varying(255) NOT NULL,
+    we_gesamt_von                   INTEGER,
+    we_gesamt_bis                   INTEGER,
+    gf_wohnen_geplant_von           DECIMAL(19, 2),
+    gf_wohnen_geplant_bis           DECIMAL(19, 2),
     CONSTRAINT personal_filter_sobon_relevant_check CHECK (((sobon_relevant)::text <> 'UNSPECIFIED'::text))
 );
 

--- a/src/main/resources/db/migration/V39__ISI2-833_Persoenliche_Filter.sql
+++ b/src/main/resources/db/migration/V39__ISI2-833_Persoenliche_Filter.sql
@@ -11,7 +11,7 @@ CREATE TABLE isidbuser.personal_filter
     created_date_time       TIMESTAMP              NOT NULL,
     last_modified_date_time TIMESTAMP              NOT NULL,
 
-    personalid              character varying(36)  NOT NULL,
+    personalid              character varying(255) NOT NULL,
     filter_name             character varying(255) NOT NULL,
 
     -- Embedded FilterSettings

--- a/src/test/java/de/muenchen/isi/domain/service/search/PersonalFilterServiceTest.java
+++ b/src/test/java/de/muenchen/isi/domain/service/search/PersonalFilterServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 
 import de.muenchen.isi.domain.exception.EntityNotFoundException;
 import de.muenchen.isi.domain.exception.OptimisticLockingException;
+import de.muenchen.isi.domain.exception.UserRoleNotAllowedException;
 import de.muenchen.isi.domain.mapper.PersonalFilterDomainMapper;
 import de.muenchen.isi.domain.model.search.filter.PersonalFilterRequestModel;
 import de.muenchen.isi.domain.model.search.filter.PersonalFilterResponseModel;
@@ -70,7 +71,7 @@ class PersonalFilterServiceTest {
         when(authenticationUtils.getUserSub()).thenReturn(userSub);
         when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(true);
 
-        assertThrows(IllegalAccessException.class, () -> personalFilterService.getPersonalFilters());
+        assertThrows(UserRoleNotAllowedException.class, () -> personalFilterService.getPersonalFilters());
     }
 
     @Test
@@ -112,7 +113,7 @@ class PersonalFilterServiceTest {
         when(personalFilterRepository.findByIdAndPersonalID(filterId, userSub)).thenReturn(null);
         when(personalFilterRepository.findById(filterId)).thenReturn(Optional.of(new PersonalFilter()));
 
-        assertThrows(IllegalAccessException.class, () -> personalFilterService.getByFilterID(filterId));
+        assertThrows(UserRoleNotAllowedException.class, () -> personalFilterService.getByFilterID(filterId));
     }
 
     @Test
@@ -162,7 +163,7 @@ class PersonalFilterServiceTest {
         when(personalFilterRepository.findByIdAndPersonalID(filterId, userSub)).thenReturn(null);
         when(personalFilterRepository.findById(filterId)).thenReturn(Optional.of(new PersonalFilter()));
 
-        assertThrows(IllegalAccessException.class, () -> personalFilterService.update(requestModel));
+        assertThrows(UserRoleNotAllowedException.class, () -> personalFilterService.update(requestModel));
     }
 
     @Test
@@ -206,9 +207,9 @@ class PersonalFilterServiceTest {
         PersonalFilterRequestModel requestModel = new PersonalFilterRequestModel();
 
         when(authenticationUtils.getUserSub()).thenReturn(userSub);
-        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false, true);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(true);
 
-        assertThrows(IllegalAccessException.class, () -> personalFilterService.save(requestModel));
+        assertThrows(UserRoleNotAllowedException.class, () -> personalFilterService.save(requestModel));
     }
 
     @Test
@@ -264,6 +265,6 @@ class PersonalFilterServiceTest {
         when(personalFilterRepository.findByIdAndPersonalID(filterId, userSub)).thenReturn(null);
         when(personalFilterRepository.findById(filterId)).thenReturn(Optional.of(new PersonalFilter()));
 
-        assertThrows(IllegalAccessException.class, () -> personalFilterService.delete(filterId));
+        assertThrows(UserRoleNotAllowedException.class, () -> personalFilterService.delete(filterId));
     }
 }

--- a/src/test/java/de/muenchen/isi/domain/service/search/PersonalFilterServiceTest.java
+++ b/src/test/java/de/muenchen/isi/domain/service/search/PersonalFilterServiceTest.java
@@ -1,0 +1,269 @@
+package de.muenchen.isi.domain.service.search;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import de.muenchen.isi.domain.exception.EntityNotFoundException;
+import de.muenchen.isi.domain.exception.OptimisticLockingException;
+import de.muenchen.isi.domain.mapper.PersonalFilterDomainMapper;
+import de.muenchen.isi.domain.model.search.filter.PersonalFilterRequestModel;
+import de.muenchen.isi.domain.model.search.filter.PersonalFilterResponseModel;
+import de.muenchen.isi.infrastructure.entity.search.filter.PersonalFilter;
+import de.muenchen.isi.infrastructure.repository.search.PersonalFilterRepository;
+import de.muenchen.isi.security.AuthenticationUtils;
+import java.util.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PersonalFilterServiceTest {
+
+    private PersonalFilterService personalFilterService;
+
+    @Mock
+    private PersonalFilterDomainMapper personalFilterDomainMapper;
+
+    @Mock
+    private AuthenticationUtils authenticationUtils;
+
+    @Mock
+    private PersonalFilterRepository personalFilterRepository;
+
+    @BeforeEach
+    void setUp() {
+        personalFilterService = new PersonalFilterService(
+            personalFilterDomainMapper,
+            authenticationUtils,
+            personalFilterRepository
+        );
+        Mockito.reset(personalFilterDomainMapper, authenticationUtils, personalFilterRepository);
+    }
+
+    @Test
+    void getPersonalFilters() throws Exception {
+        String userSub = "userSub";
+        List<PersonalFilter> entities = List.of(new PersonalFilter());
+        List<PersonalFilterResponseModel> models = List.of(new PersonalFilterResponseModel());
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false);
+        when(personalFilterRepository.findByPersonalID(userSub)).thenReturn(entities);
+        when(personalFilterDomainMapper.entities2Models(entities)).thenReturn(models);
+
+        List<PersonalFilterResponseModel> result = personalFilterService.getPersonalFilters();
+        assertThat(result, is(models));
+        verify(personalFilterRepository).findByPersonalID(userSub);
+        verify(personalFilterDomainMapper).entities2Models(entities);
+    }
+
+    @Test
+    void getPersonalFiltersUnauthenticatedUser() {
+        String userSub = "fallback";
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(true);
+
+        assertThrows(IllegalAccessException.class, () -> personalFilterService.getPersonalFilters());
+    }
+
+    @Test
+    void getByFilterID() throws Exception {
+        UUID filterId = UUID.randomUUID();
+        String userSub = "userSub";
+        PersonalFilter entity = new PersonalFilter();
+        PersonalFilterResponseModel model = new PersonalFilterResponseModel();
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false);
+        when(personalFilterRepository.findByIdAndPersonalID(filterId, userSub)).thenReturn(entity);
+        when(personalFilterDomainMapper.entity2Model(entity)).thenReturn(model);
+
+        PersonalFilterResponseModel result = personalFilterService.getByFilterID(filterId);
+        assertThat(result, is(model));
+    }
+
+    @Test
+    void getByFilterIDUnauthenticatedUser() {
+        UUID filterId = UUID.randomUUID();
+        String userSub = "userSub";
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false);
+        when(personalFilterRepository.findByIdAndPersonalID(filterId, userSub)).thenReturn(null);
+        when(personalFilterRepository.findById(filterId)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> personalFilterService.getByFilterID(filterId));
+    }
+
+    @Test
+    void getByFilterIDNotOwner() {
+        UUID filterId = UUID.randomUUID();
+        String userSub = "userSub";
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false);
+        when(personalFilterRepository.findByIdAndPersonalID(filterId, userSub)).thenReturn(null);
+        when(personalFilterRepository.findById(filterId)).thenReturn(Optional.of(new PersonalFilter()));
+
+        assertThrows(IllegalAccessException.class, () -> personalFilterService.getByFilterID(filterId));
+    }
+
+    @Test
+    void update() throws Exception {
+        UUID filterId = UUID.randomUUID();
+        String userSub = "userSub";
+        PersonalFilterRequestModel requestModel = new PersonalFilterRequestModel();
+        requestModel.setId(filterId);
+        PersonalFilter entity = new PersonalFilter();
+        PersonalFilterResponseModel responseModel = new PersonalFilterResponseModel();
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false);
+        when(personalFilterRepository.findByIdAndPersonalID(filterId, userSub)).thenReturn(entity);
+        when(personalFilterRepository.saveAndFlush(entity)).thenReturn(entity);
+        when(personalFilterDomainMapper.entity2Model(entity)).thenReturn(responseModel);
+
+        PersonalFilterResponseModel result = personalFilterService.update(requestModel);
+        assertThat(result, is(responseModel));
+        verify(personalFilterDomainMapper).updateEntityFromModel(requestModel, entity);
+    }
+
+    @Test
+    void updateNotFound() {
+        UUID filterId = UUID.randomUUID();
+        String userSub = "userSub";
+        PersonalFilterRequestModel requestModel = new PersonalFilterRequestModel();
+        requestModel.setId(filterId);
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false);
+        when(personalFilterRepository.findByIdAndPersonalID(filterId, userSub)).thenReturn(null);
+        when(personalFilterRepository.findById(filterId)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> personalFilterService.update(requestModel));
+    }
+
+    @Test
+    void updateNotOwner() {
+        UUID filterId = UUID.randomUUID();
+        String userSub = "userSub";
+        PersonalFilterRequestModel requestModel = new PersonalFilterRequestModel();
+        requestModel.setId(filterId);
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false);
+        when(personalFilterRepository.findByIdAndPersonalID(filterId, userSub)).thenReturn(null);
+        when(personalFilterRepository.findById(filterId)).thenReturn(Optional.of(new PersonalFilter()));
+
+        assertThrows(IllegalAccessException.class, () -> personalFilterService.update(requestModel));
+    }
+
+    @Test
+    void updateOptimisticLocking() {
+        UUID filterId = UUID.randomUUID();
+        String userSub = "userSub";
+        PersonalFilterRequestModel requestModel = new PersonalFilterRequestModel();
+        requestModel.setId(filterId);
+        PersonalFilter entity = new PersonalFilter();
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false);
+        when(personalFilterRepository.findByIdAndPersonalID(filterId, userSub)).thenReturn(entity);
+        doThrow(new ObjectOptimisticLockingFailureException("test", "test"))
+            .when(personalFilterRepository)
+            .saveAndFlush(entity);
+
+        assertThrows(OptimisticLockingException.class, () -> personalFilterService.update(requestModel));
+    }
+
+    @Test
+    void save() throws Exception {
+        String userSub = "userSub";
+        PersonalFilterRequestModel requestModel = new PersonalFilterRequestModel();
+        PersonalFilter entity = new PersonalFilter();
+        PersonalFilterResponseModel responseModel = new PersonalFilterResponseModel();
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false);
+        when(personalFilterDomainMapper.model2Entity(requestModel)).thenReturn(entity);
+        when(personalFilterRepository.saveAndFlush(entity)).thenReturn(entity);
+        when(personalFilterDomainMapper.entity2Model(entity)).thenReturn(responseModel);
+
+        PersonalFilterResponseModel result = personalFilterService.save(requestModel);
+        assertThat(result, is(responseModel));
+    }
+
+    @Test
+    void saveUnauthenticatedUser() {
+        String userSub = "userSub";
+        PersonalFilterRequestModel requestModel = new PersonalFilterRequestModel();
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false, true);
+
+        assertThrows(IllegalAccessException.class, () -> personalFilterService.save(requestModel));
+    }
+
+    @Test
+    void save_optimisticLocking_throwsOptimisticLockingException() throws Exception {
+        String userSub = "userSub";
+        PersonalFilterRequestModel requestModel = new PersonalFilterRequestModel();
+        PersonalFilter entity = new PersonalFilter();
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false);
+        when(personalFilterDomainMapper.model2Entity(requestModel)).thenReturn(entity);
+        doThrow(new ObjectOptimisticLockingFailureException("test", "test"))
+            .when(personalFilterRepository)
+            .saveAndFlush(entity);
+
+        assertThrows(OptimisticLockingException.class, () -> personalFilterService.save(requestModel));
+    }
+
+    @Test
+    void delete() throws Exception {
+        UUID filterId = UUID.randomUUID();
+        String userSub = "userSub";
+        PersonalFilter entity = new PersonalFilter();
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false);
+        when(personalFilterRepository.findByIdAndPersonalID(filterId, userSub)).thenReturn(entity);
+
+        personalFilterService.delete(filterId);
+        verify(personalFilterRepository).deleteById(filterId);
+    }
+
+    @Test
+    void delete_NotFound() {
+        UUID filterId = UUID.randomUUID();
+        String userSub = "userSub";
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false);
+        when(personalFilterRepository.findByIdAndPersonalID(filterId, userSub)).thenReturn(null);
+        when(personalFilterRepository.findById(filterId)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> personalFilterService.delete(filterId));
+    }
+
+    @Test
+    void deleteNotOwner() throws Exception {
+        UUID filterId = UUID.randomUUID();
+        String userSub = "userSub";
+
+        when(authenticationUtils.getUserSub()).thenReturn(userSub);
+        when(authenticationUtils.isSubFromUnauthenticatedUser(userSub)).thenReturn(false);
+        when(personalFilterRepository.findByIdAndPersonalID(filterId, userSub)).thenReturn(null);
+        when(personalFilterRepository.findById(filterId)).thenReturn(Optional.of(new PersonalFilter()));
+
+        assertThrows(IllegalAccessException.class, () -> personalFilterService.delete(filterId));
+    }
+}


### PR DESCRIPTION
**Übersicht**

- Hinzufügen der Entität "PersonalFilter" um Filtereinstellungen zu persistieren sowie zugehöriges Migrationsskript und Repository
- Hinzufügen von PersonalFilter-Request und -Response DTO Typen und Modellen. Bewusst nur ein Typ in jede Richtung, auch wenn dadurch gewisse Logik (z.B. bei Request Patch muss eine filterID angegeben werden) erst auf service-Ebene explizit greift.
- Controller und Service für CRUD-Operationen für persönliche Filter, sowie ein Get-Endpunkt um alle PersonalFilter eines Nutzers zurück zu geben.

**Reference**

- siehe ISI2-833


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating, viewing, editing, and deleting personal search filters.
  * Personal filters support numeric ranges, boolean options, statuses, locations, planning areas, and infrastructure criteria.
  * Added persistent storage for personal filter settings.
  * Filters are associated with the current user and protected from unauthorized updates or deletion.
  * Filter details can be retrieved or deleted using the filter’s unique identifier.
  * Added validation for filter names, settings, and supported relevance values.
  * New filters now return a clear creation confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->